### PR TITLE
Fixes juju-lib to 3.0.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,9 +2,8 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[BUG]"
-labels: ''
-assignees: ''
-
+labels: ""
+assignees: ""
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -27,10 +27,11 @@ If applicable, add screenshots to help explain your problem.
 If applicable, add logs to help explain your problem.
 
 **Environment**
- - Vault version: [e.g. 1.11.2]
- - Juju version: [e.g. 2.9.23]
- - Cloud Environment [e.g. GKE]
- - Kubernetes version [e.g. 1.22]
+
+- Vault version: [e.g. 1.11.2]
+- Juju version: [e.g. 2.9.23]
+- Cloud Environment [e.g. GKE]
+- Kubernetes version [e.g. 1.22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==2.9.28.1
+    juju==2.9.38.1
     pytest
     pytest-operator
     -r{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ deps =
     types-PyYAML
     pytest
     pytest-operator
-    juju
+    juju==2.9.28.1
     types-setuptools
     types-toml
 setenv =
@@ -75,7 +75,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju
+    juju==2.9.28.1
     pytest
     pytest-operator
     -r{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ deps =
     types-PyYAML
     pytest
     pytest-operator
-    juju==2.9.28.1
+    juju==3.0.4
     types-setuptools
     types-toml
 setenv =
@@ -75,7 +75,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==2.9.38.1
+    juju==3.0.4
     pytest
     pytest-operator
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
# Description

Fixes juju-lib to 2.9.28.1

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
