### PR TITLE
Uses Ubuntu 22.04 to build and test the charm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
 
   integration-test:
     name: Integration tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -6,10 +6,10 @@ type: "charm"
 bases:
   - build-on:
     - name: "ubuntu"
-      channel: "20.04"
+      channel: "22.04"
     run-on:
     - name: "ubuntu"
-      channel: "20.04"
+      channel: "22.04"
 
 parts:
   charm:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -87,7 +87,7 @@ class TestVaultK8s:
             resources=resources,
             application_name=APPLICATION_NAME,
             trust=True,
-            series="focal",
+            series="jammy",
         )
 
     @pytest.mark.abort_on_fail


### PR DESCRIPTION
# Description

The goal of the PR is to fix the following:
- The Cryptography library is complaining about missing `GLIBC_2.33` which seems not to be present on ubuntu20.04, this causes the charm to be in error statue.

When using Ubuntu 22.04 to build the charm, the charm deploys correctly.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
