### PR TITLE
Removes `generate-certificate` juju action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -10,15 +10,3 @@ authorise-charm:
       description: Token to use to authorise charm.
   required:
   - token
-generate-certificate:
-  description: Generate a certificate against the Vault PKI.
-  properties:
-    cn:
-      type: string
-      description: >-
-        CN (Common Name) field of the new certificate
-    sans:
-      type: string
-      description: >-
-        Space delimited list of Subject Alternate Name/IP addresse(s).
-      default: ""

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,8 +17,6 @@ from charms.observability_libs.v1.kubernetes_service_patch import (
 from charms.tls_certificates_interface.v1.tls_certificates import (
     CertificateCreationRequestEvent,
     TLSCertificatesProvidesV1,
-    generate_csr,
-    generate_private_key,
 )
 from ops.charm import ActionEvent, CharmBase, ConfigChangedEvent
 from ops.framework import StoredState

--- a/src/charm.py
+++ b/src/charm.py
@@ -59,9 +59,6 @@ class VaultCharm(CharmBase):
         self.framework.observe(self.on.vault_pebble_ready, self._on_config_changed)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.authorise_charm_action, self._on_authorise_charm_action)
-        self.framework.observe(
-            self.on.generate_certificate_action, self._on_generate_certificate_action
-        )
         self.service_patcher = KubernetesServicePatch(
             charm=self,
             ports=[ServicePort(name="vault", port=8200)],
@@ -208,34 +205,6 @@ class VaultCharm(CharmBase):
             self._stored.role_id = role_id
             self._stored.secret_id = secret_id
             self.unit.status = ActiveStatus()
-
-    def _on_generate_certificate_action(self, event: ActionEvent) -> None:
-        """Generates TLS Certificate.
-
-        Generates a private key, creates a CSR based on user provided parameters and asks
-        Vault for a certificate.
-
-        Args:
-            event: Juju event.
-
-        Returns:
-            None
-        """
-        private_key = generate_private_key()
-        csr = generate_csr(
-            private_key=private_key,
-            subject=event.params["cn"],
-            sans=event.params["sans"],  # type: ignore[arg-type]
-        )
-        certificate = self.vault.issue_certificate(certificate_signing_request=csr.decode())
-        event.set_results(
-            {
-                "private-key": private_key.decode(),
-                "certificate": certificate["certificate"],
-                "ca-chain": certificate["ca_chain"],
-                "issuing-ca": certificate["issuing_ca"],
-            }
-        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -175,24 +175,3 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_authorise_charm_action(event)
 
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
-
-    @patch("vault.Vault.issue_certificate")
-    def test_given_when_on_generate_certificate_action_then(self, patch_issue_certificate):
-        common_name = "whatever common name"
-        certificate = "whatever certificate"
-        ca_chain = "whatever ca chain"
-        issuing_ca = "whatever issuing ca"
-        patch_issue_certificate.return_value = {
-            "certificate": certificate,
-            "ca_chain": ca_chain,
-            "issuing_ca": issuing_ca,
-        }
-        event = Mock()
-        event.params = {"cn": common_name, "sans": ""}
-
-        self.harness.charm._on_generate_certificate_action(event=event)
-
-        args, kwargs = event.set_results.call_args
-        assert args[0]["certificate"] == certificate
-        assert args[0]["ca-chain"] == ca_chain
-        assert args[0]["issuing-ca"] == issuing_ca


### PR DESCRIPTION
# Description

This PR removes the `generate-certificate` Juju action. Certificates are generated leveraging Juju relations.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
