### PR TITLE
[Feat] Uses the Canonical ROCK for Vault instead of upstream Docker image

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -20,6 +20,8 @@ containers:
     mounts:
       - storage: vault-raft
         location: /vault/raft
+      - storage: config
+        location: /vault/config
       - storage: certs
         location: /vault/certs
 
@@ -27,12 +29,15 @@ resources:
   vault-image:
     type: oci-image
     description: OCI image for Vault
-    upstream-source: vault:1.13.3
+    upstream-source: ghcr.io/canonical/vault:1.14.3
 
 storage:
   vault-raft:
     type: filesystem
     minimum-size: 10G
+  config:
+    type: filesystem
+    minimum-size: 50M
   certs:
     type: filesystem
     minimum-size: 50M

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 ops
 hvac
+jinja2
 jsonschema
 lightkube
 lightkube-models
+pyhcl
 requests
 jsonschema
 cryptography

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,11 +6,11 @@
 
 For more information on Vault, please visit https://www.vaultproject.io/.
 """
-
 import json
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
+import hcl  # type: ignore[import]
 from charms.observability_libs.v1.kubernetes_service_patch import (
     KubernetesServicePatch,
     ServicePort,
@@ -21,6 +21,7 @@ from charms.tls_certificates_interface.v2.tls_certificates import (
     generate_csr,
     generate_private_key,
 )
+from jinja2 import Environment, FileSystemLoader
 from ops.charm import (
     CharmBase,
     ConfigChangedEvent,
@@ -43,10 +44,43 @@ from vault import Vault
 logger = logging.getLogger(__name__)
 
 VAULT_STORAGE_PATH = "/vault/raft"
+CONFIG_TEMPLATE_DIR_PATH = "src/templates/"
+CONFIG_TEMPLATE_NAME = "vault.hcl.j2"
+VAULT_CONFIG_FILE_PATH = "/vault/config/vault.hcl"
 TLS_CERT_FILE_PATH = "/vault/certs/cert.pem"
 TLS_KEY_FILE_PATH = "/vault/certs/key.pem"
 TLS_CA_FILE_PATH = "/vault/certs/ca.pem"
 PEER_RELATION_NAME = "vault-peers"
+
+
+def render_vault_config_file(
+    default_lease_ttl: str,
+    max_lease_ttl: str,
+    cluster_address: str,
+    api_address: str,
+    tls_cert_file: str,
+    tls_key_file: str,
+    tcp_address: str,
+    raft_storage_path: str,
+    node_id: str,
+    retry_joins: List[Dict[str, str]],
+) -> str:
+    """Render the Vault config file."""
+    jinja2_environment = Environment(loader=FileSystemLoader(CONFIG_TEMPLATE_DIR_PATH))
+    template = jinja2_environment.get_template(CONFIG_TEMPLATE_NAME)
+    content = template.render(
+        default_lease_ttl=default_lease_ttl,
+        max_lease_ttl=max_lease_ttl,
+        cluster_address=cluster_address,
+        api_address=api_address,
+        tls_cert_file=tls_cert_file,
+        tls_key_file=tls_key_file,
+        tcp_address=tcp_address,
+        raft_storage_path=raft_storage_path,
+        node_id=node_id,
+        retry_joins=retry_joins,
+    )
+    return content
 
 
 class PeerSecretError(Exception):
@@ -155,6 +189,7 @@ class VaultCharm(CharmBase):
                 private_key=private_key,
                 ca_certificate=ca_certificate,
             )
+        self._generate_vault_config_file()
         self._set_pebble_plan()
         vault = Vault(url=self._api_address)
         if not vault.is_api_available():
@@ -211,6 +246,7 @@ class VaultCharm(CharmBase):
                 ca_certificate=ca_certificate,
             )
         self.unit.status = MaintenanceStatus("Preparing vault")
+        self._generate_vault_config_file()
         self._set_pebble_plan()
         vault = Vault(url=self._api_address)
         vault.set_token(token=root_token)
@@ -321,6 +357,59 @@ class VaultCharm(CharmBase):
         if existing_ca_certificate.read() != ca_certificate:
             return False
         return True
+
+    def _config_file_pushed_to_workload(self) -> bool:
+        """Check if the config file is pushed to the workload."""
+        if not self._container.exists(path=VAULT_CONFIG_FILE_PATH):
+            return False
+        return True
+
+    def _generate_vault_config_file(self) -> None:
+        """Handles creation of the Vault config file."""
+        retry_joins = [
+            {
+                "leader_api_addr": node_api_address,
+                "leader_ca_cert_file": TLS_CA_FILE_PATH,
+            }
+            for node_api_address in self._other_peer_node_api_addresses()
+        ]
+        logger.info("Retry joins: %s", retry_joins)
+
+        content = render_vault_config_file(
+            default_lease_ttl=self.model.config["default_lease_ttl"],
+            max_lease_ttl=self.model.config["max_lease_ttl"],
+            cluster_address=f"https://{self._bind_address}:{self.VAULT_CLUSTER_PORT}",
+            api_address=self._api_address,
+            tcp_address=f"[::]:{self.VAULT_PORT}",
+            tls_cert_file=TLS_CERT_FILE_PATH,
+            tls_key_file=TLS_KEY_FILE_PATH,
+            raft_storage_path=VAULT_STORAGE_PATH,
+            node_id=self._node_id,
+            retry_joins=retry_joins,
+        )
+        if not self._config_file_content_matches(content=content):
+            self._push_config_file_to_workload(content=content)
+
+    def _config_file_content_matches(self, content: str) -> bool:
+        """Returns whether the vault config file content matches the provided content.
+
+        Returns:
+            bool: Whether the vault config file content matches
+        """
+        if not self._container.exists(path=VAULT_CONFIG_FILE_PATH):
+            return False
+        existing_content = self._container.pull(path=VAULT_CONFIG_FILE_PATH)
+        existing_config_hcl = hcl.load(existing_content)
+        new_content_hcl = hcl.loads(content)
+
+        if existing_config_hcl != new_content_hcl:
+            return False
+        return True
+
+    def _push_config_file_to_workload(self, content: str):
+        """Push the config file to the workload."""
+        self._container.push(path=VAULT_CONFIG_FILE_PATH, source=content)
+        logger.info("Pushed %s config file", VAULT_CONFIG_FILE_PATH)
 
     def _set_certificates_secret_in_peer_relation(
         self,
@@ -454,45 +543,7 @@ class VaultCharm(CharmBase):
 
     @property
     def _vault_layer(self) -> Layer:
-        """Returns pebble layer to start Vault.
-
-        Vault config options:
-            ui: Enables the built-in static web UI.
-            storage: Configures the storage backend, which represents the location for the
-                durable storage of Vault's information.
-            listener: Configures how Vault is listening for API requests.
-            default_lease_ttl: Specifies the default lease duration for Vault's tokens and secrets.
-            max_lease_ttl: Specifies the maximum possible lease duration for Vault's tokens and
-                secrets.
-            disable_mlock: mlock() ensures memory from a process on a Linux system isn't swapped
-                (written) to disk. Enabling mlock would require the operator to add IPC_LOCK
-                capabilities to the vault pod which isn't even necessary since Kubernetes, by
-                default, doesn't enable swap.
-            cluster_addr: Specifies the address to advertise to other Vault servers in the cluster
-                for request forwarding.
-            api_addr: Specifies the address (full URL) to advertise to other Vault servers in the
-                cluster for client redirection
-
-        Returns:
-            Layer: Pebble Layer
-        """
-        vault_config = {
-            "ui": True,
-            "storage": {"raft": self._get_raft_config()},
-            "listener": {
-                "tcp": {
-                    "address": f"[::]:{self.VAULT_PORT}",
-                    "tls_cert_file": TLS_CERT_FILE_PATH,
-                    "tls_key_file": TLS_KEY_FILE_PATH,
-                }
-            },
-            "default_lease_ttl": self.model.config["default_lease_ttl"],
-            "max_lease_ttl": self.model.config["max_lease_ttl"],
-            "disable_mlock": True,
-            "cluster_addr": f"https://{self._bind_address}:{self.VAULT_CLUSTER_PORT}",
-            "api_addr": self._api_address,
-        }
-
+        """Returns pebble layer to start Vault."""
         return Layer(
             {
                 "summary": "vault layer",
@@ -501,12 +552,8 @@ class VaultCharm(CharmBase):
                     "vault": {
                         "override": "replace",
                         "summary": "vault",
-                        "command": "/usr/local/bin/docker-entrypoint.sh server",
+                        "command": f"vault server -config={VAULT_CONFIG_FILE_PATH}",
                         "startup": "enabled",
-                        "environment": {
-                            "VAULT_LOCAL_CONFIG": json.dumps(vault_config),
-                            "VAULT_API_ADDR": f"https://[::]:{self.VAULT_PORT}",
-                        },
                     }
                 },
             }
@@ -540,40 +587,6 @@ class VaultCharm(CharmBase):
             for node_api_address in self._get_peer_relation_node_api_addresses()
             if node_api_address != self._api_address
         ]
-
-    def _get_raft_config(self) -> Dict[str, Any]:
-        """Returns raft config for vault.
-
-        Example of raft config:
-        {
-            "path": "/vault/raft",
-            "node_id": "vault-k8s-0",
-            "retry_join": [
-                {
-                    "leader_api_addr": "https://1.2.3.4:8200",
-                    "leader_ca_cert_file": "/vault/certs/ca.pem",
-                },
-                {
-                    "leader_api_addr": "https://5.6.7.8:8200",
-                    "leader_ca_cert_file": "/vault/certs/ca.pem",
-                }
-            ]
-        }
-        """
-        retry_join = [
-            {
-                "leader_api_addr": node_api_address,
-                "leader_ca_cert_file": TLS_CA_FILE_PATH,
-            }
-            for node_api_address in self._other_peer_node_api_addresses()
-        ]
-        raft_config: Dict[str, Any] = {
-            "path": VAULT_STORAGE_PATH,
-            "node_id": self._node_id,
-        }
-        if retry_join:
-            raft_config["retry_join"] = retry_join
-        return raft_config
 
     @property
     def _node_id(self) -> str:

--- a/src/templates/vault.hcl.j2
+++ b/src/templates/vault.hcl.j2
@@ -1,0 +1,21 @@
+ui      = true
+storage "raft" {
+  path= "{{ raft_storage_path }}"
+  node_id = "{{ node_id }}"
+  {% for retry in retry_joins %}
+  retry_join {
+    leader_api_addr = "{{ retry.leader_api_addr }}"
+    leader_ca_cert_file = "{{ retry.leader_ca_cert_file }}"
+  }
+  {% endfor %}
+  }
+listener "tcp" {
+  address       = "{{ tcp_address }}"
+  tls_cert_file = "{{ tls_cert_file }}"
+  tls_key_file  = "{{ tls_key_file }}"
+}
+default_lease_ttl = "{{ default_lease_ttl }}"
+max_lease_ttl     = "{{ max_lease_ttl }}"
+disable_mlock     = true
+cluster_addr      = "{{ cluster_address }}"
+api_addr          = "{{ api_address }}"

--- a/tests/unit/config.hcl
+++ b/tests/unit/config.hcl
@@ -1,0 +1,16 @@
+ui      = true
+storage "raft" {
+  path= "/vault/raft"
+  node_id = "whatever-vault-k8s/0"
+
+  }
+listener "tcp" {
+  address       = "[::]:8200"
+  tls_cert_file = "/vault/certs/cert.pem"
+  tls_key_file  = "/vault/certs/key.pem"
+}
+default_lease_ttl = "168h"
+max_lease_ttl     = "720h"
+disable_mlock     = true
+cluster_addr      = "https://1.2.3.4:8201"
+api_addr          = "https://1.2.3.4:8200"


### PR DESCRIPTION
# Description

Uses the Canonical ROCK for Vault instead of upstream Docker image

This PR is dependent on the ROCK PR being merged first:
- https://github.com/canonical/vault-rock/pull/2

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
