### PR TITLE
Fix: Publish library when publishing charm

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -35,10 +35,10 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: latest/edge
       - name: Publish libs
-        env:
-          CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"
-        run: |
-          charmcraft publish-lib charms.vault_k8s.v0.vault_kv
+        uses: canonical/charming-actions/release-libraries@2.4.0
+        with:
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -34,6 +34,11 @@ jobs:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: latest/edge
+      - name: Publish libs
+        env:
+          CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"
+        run: |
+          charmcraft publish-lib charms.vault_k8s.v0.vault_kv
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
# Description

Publishes vault_kv library when we publish the charm.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
