### PR TITLE
[bugfix] Fixes retry join comparison in config file

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -89,6 +89,43 @@ def render_vault_config_file(
     return content
 
 
+def config_file_content_matches(existing_content: str, new_content: str) -> bool:
+    """Returns whether two Vault config file contents match.
+
+    We check if the retry_join addresses match, and then we check if the rest of the config
+    file matches.
+
+    Returns:
+        bool: Whether the vault config file content matches
+    """
+    existing_config_hcl = hcl.loads(existing_content)
+    new_content_hcl = hcl.loads(new_content)
+    if not existing_config_hcl:
+        logger.info("Existing config file is empty")
+        return existing_config_hcl == new_content_hcl
+    if not new_content_hcl:
+        logger.info("New config file is empty")
+        return existing_config_hcl == new_content_hcl
+
+    new_retry_joins = new_content_hcl["storage"]["raft"].pop("retry_join", [])
+    existing_retry_joins = existing_config_hcl["storage"]["raft"].pop("retry_join", [])
+
+    # If there is only one retry join, it is a dict
+    if isinstance(new_retry_joins, dict):
+        new_retry_joins = [new_retry_joins]
+    if isinstance(existing_retry_joins, dict):
+        existing_retry_joins = [existing_retry_joins]
+
+    new_retry_join_api_addresses = set(address["leader_api_addr"] for address in new_retry_joins)
+    existing_retry_join_api_addresses = set(
+        address["leader_api_addr"] for address in existing_retry_joins
+    )
+    return (
+        new_retry_join_api_addresses == existing_retry_join_api_addresses
+        and new_content_hcl == existing_config_hcl
+    )
+
+
 class PeerSecretError(Exception):
     """Exception raised when a peer secret is not found."""
 
@@ -593,42 +630,13 @@ class VaultCharm(CharmBase):
             node_id=self._node_id,
             retry_joins=retry_joins,
         )
-        if not self._config_file_content_matches(content=content):
+        existing_content = ""
+        if self._container.exists(path=VAULT_CONFIG_FILE_PATH):
+            existing_content_stringio = self._container.pull(path=VAULT_CONFIG_FILE_PATH)
+            existing_content = existing_content_stringio.read()  # type: ignore[assignment]
+
+        if not config_file_content_matches(existing_content=existing_content, new_content=content):
             self._push_config_file_to_workload(content=content)
-
-    def _config_file_content_matches(self, content: str) -> bool:
-        """Returns whether the vault config file content matches the provided content.
-
-        We check if the retry_join addresses match, and then we check if the rest of the config
-        file matches.
-
-        Returns:
-            bool: Whether the vault config file content matches
-        """
-        if not self._container.exists(path=VAULT_CONFIG_FILE_PATH):
-            return False
-        existing_content = self._container.pull(path=VAULT_CONFIG_FILE_PATH)
-        existing_config_hcl = hcl.load(existing_content)
-        new_content_hcl = hcl.loads(content)
-        new_retry_joins = new_content_hcl["storage"]["raft"].pop("retry_join", [])
-        existing_retry_joins = existing_config_hcl["storage"]["raft"].pop("retry_join", [])
-
-        # If there is only one retry join, it is a dict
-        if isinstance(new_retry_joins, dict):
-            new_retry_joins = [new_retry_joins]
-        if isinstance(existing_retry_joins, dict):
-            existing_retry_joins = [existing_retry_joins]
-
-        new_retry_join_api_addresses = set(
-            address["leader_api_addr"] for address in new_retry_joins
-        )
-        existing_retry_join_api_addresses = set(
-            address["leader_api_addr"] for address in existing_retry_joins
-        )
-        return (
-            new_retry_join_api_addresses == existing_retry_join_api_addresses
-            and new_content_hcl == existing_config_hcl
-        )
 
     def _push_config_file_to_workload(self, content: str):
         """Push the config file to the workload."""

--- a/tests/unit/config_with_raft_peers.hcl
+++ b/tests/unit/config_with_raft_peers.hcl
@@ -1,0 +1,31 @@
+ui      = true
+storage "raft" {
+  path= "/vault/raft"
+  node_id = "whatever-vault-k8s/0"
+   retry_join {
+    leader_api_addr = "http://127.0.0.1:8200"
+    leader_ca_cert_file = "/path/to/ca1"
+  }
+  retry_join {
+    leader_api_addr = "http://127.0.0.2:8200"
+    leader_ca_cert_file = "/path/to/ca1"
+  }
+
+  }
+listener "tcp" {
+  telemetry {
+    unauthenticated_metrics_access = true
+  }
+  address       = "[::]:8200"
+  tls_cert_file = "/vault/certs/cert.pem"
+  tls_key_file  = "/vault/certs/key.pem"
+}
+default_lease_ttl = "168h"
+max_lease_ttl     = "720h"
+disable_mlock     = true
+cluster_addr      = "https://1.2.3.4:8201"
+api_addr          = "https://1.2.3.4:8200"
+telemetry {
+  disable_hostname = true
+  prometheus_retention_time = "12h"
+}

--- a/tests/unit/config_with_raft_peers_equivalent.hcl
+++ b/tests/unit/config_with_raft_peers_equivalent.hcl
@@ -1,0 +1,32 @@
+ui      = true
+storage "raft" {
+  path= "/vault/raft"
+  node_id = "whatever-vault-k8s/0"
+  # The order is different from in "config_with_raft_peers.hcl"
+  retry_join {
+    leader_api_addr = "http://127.0.0.2:8200"
+    leader_ca_cert_file = "/path/to/ca1"
+  }
+   retry_join {
+    leader_api_addr = "http://127.0.0.1:8200"
+    leader_ca_cert_file = "/path/to/ca1"
+  }
+
+  }
+listener "tcp" {
+  telemetry {
+    unauthenticated_metrics_access = true
+  }
+  address       = "[::]:8200"
+  tls_cert_file = "/vault/certs/cert.pem"
+  tls_key_file  = "/vault/certs/key.pem"
+}
+default_lease_ttl = "168h"
+max_lease_ttl     = "720h"
+disable_mlock     = true
+cluster_addr      = "https://1.2.3.4:8201"
+api_addr          = "https://1.2.3.4:8200"
+telemetry {
+  disable_hostname = true
+  prometheus_retention_time = "12h"
+}


### PR DESCRIPTION
# Description

Fixes retry join comparison in config file. The retryjoin stanza is typically a list. When comparing the file content, we should not care about ordering, therefore we are now converting to set before making the comparison.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
