### PR TITLE
Simplify test by using Harness get_filesystem_root and add_network

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cosl
-ops
+ops ~= 2.7.0
 hvac
 jinja2
 jsonschema


### PR DESCRIPTION
Per discussion with Guillaume, we want to reduce the number of mocks in tests. In particularly, here we can use:

- Harness.get_filesystem_root method to make to make the push/pull operations more real and avoid patching Container push/pull/exists
- Harness.add_network to avoid patching Model.get_binding

In addition, tighten up the test a fair bit. Instead of exists always returning True, create the specific files we're looking for.

Also assert that vault.unseal() was actually called. It was too easy to break the test and accidentally follow the wrong code path, and the test still succeeded. For example, if you removed the patch_get_binding before, the test would still pass fine, but would be following one of the early returns -- not what the test was trying to test for.

Also pin ops to a version compatible with the latest version to ensure we have the newish features.

Not saying you have to merge this as is, but this is an example of how to 1) tighten up assertions, and 2) use the newish filesystem and network fakes in Harness.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
