### PR TITLE
feat: Enables audit device upon init

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/lib/charms/vault_k8s/v0/vault_kv.py
@@ -134,7 +134,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -401,6 +401,7 @@ class VaultCharm(CharmBase):
             return
         if vault.is_sealed():
             vault.unseal(unseal_keys=unseal_keys)
+        vault.wait_for_unseal()
         vault.enable_audit_device(device_type="file", path="stdout")
         self._set_peer_relation_node_api_address()
         self.unit.status = ActiveStatus()

--- a/src/charm.py
+++ b/src/charm.py
@@ -237,7 +237,7 @@ class VaultCharm(CharmBase):
     def _on_install(self, event: InstallEvent):
         """Handler triggered when the charm is installed.
 
-        Sets pebble plan, initializes vault, and unseals vault.
+        Sets pebble plan, initializes vault, enable audit device, and unseals vault.
         """
         if self.unit.is_leader():
             self._on_install_leader(event)
@@ -401,6 +401,7 @@ class VaultCharm(CharmBase):
             return
         if vault.is_sealed():
             vault.unseal(unseal_keys=unseal_keys)
+        vault.enable_audit_device(device_type="file", path="stdout")
         self._set_peer_relation_node_api_address()
         self.unit.status = ActiveStatus()
 

--- a/src/vault.py
+++ b/src/vault.py
@@ -104,6 +104,15 @@ class Vault:
             mount_policy = fd.read()
         self._client.sys.create_or_update_policy(policy, mount_policy.format(mount=mount))
 
+    def enable_audit_device(self, device_type: str, path: str) -> None:
+        """Enable a new audit device at the supplied path."""
+        if device_type + "/" not in self._client.sys.list_enabled_audit_devices()["data"].keys():
+            self._client.sys.enable_audit_device(
+                device_type=device_type,
+                options={"file_path": path},
+            )
+            logger.info("Enabled audit device of type: %s, using path: %s", device_type, path)
+
     def configure_approle(self, name: str, cidrs: List[str], policies: List[str]) -> str:
         """Create/update a role within vault associating the supplied policies."""
         self._client.auth.approle.create_or_update_approle(

--- a/src/vault.py
+++ b/src/vault.py
@@ -48,21 +48,21 @@ class Vault:
         """Returns whether Vault is sealed."""
         return self._client.sys.is_sealed()
 
-    def wait_for_unseal(self) -> None:
+    def wait_for_unseal(self, max_attempts: int = 15) -> None:
         """Waits for Vault to be unsealed.
 
         Expected to be called after attempting to unseal Vault.
         If it times out, raises a TimeoutError.
+
+        Args:
+            max_attempts: The maximum number of attempts to check if Vault is unsealed.
         """
-        elapsed_time = 0
-        timeout = 30
-        while elapsed_time < 30:
+        for _ in range(max_attempts):
             if not self.is_sealed():
                 return
             logger.info("Vault is sealed, waiting for unseal")
             time.sleep(2)
-            elapsed_time += 2
-        raise TimeoutError(f"Vault is still sealed after waiting for {timeout} seconds")
+        raise TimeoutError(f"Vault is still sealed after checking {max_attempts} times")
 
     def unseal(self, unseal_keys: List[str]) -> None:
         """Unseal Vault."""

--- a/src/vault.py
+++ b/src/vault.py
@@ -63,6 +63,11 @@ class Vault:
                 return
             logger.info("Vault is sealed, waiting for unseal")
             time.sleep(2)
+
+        # One more check after the loop to catch any edge cases.
+        if not self.is_sealed():
+            return
+
         raise TimeoutError(f"Vault is still sealed {timeout} seconds")
 
     def unseal(self, unseal_keys: List[str]) -> None:
@@ -136,6 +141,7 @@ class Vault:
                     "Failed to enable audit device of type: %s, using path: %s", device_type, path
                 )
             logger.info("Enabled audit device of type: %s, using path: %s", device_type, path)
+        logger.info("Audit device of type: %s, using path: %s already enabled", device_type, path)
 
     def configure_approle(self, name: str, cidrs: List[str], policies: List[str]) -> str:
         """Create/update a role within vault associating the supplied policies."""

--- a/src/vault.py
+++ b/src/vault.py
@@ -48,21 +48,22 @@ class Vault:
         """Returns whether Vault is sealed."""
         return self._client.sys.is_sealed()
 
-    def wait_for_unseal(self, max_attempts: int = 15) -> None:
+    def wait_for_unseal(self, timeout: int = 30) -> None:
         """Waits for Vault to be unsealed.
 
         Expected to be called after attempting to unseal Vault.
         If it times out, raises a TimeoutError.
 
         Args:
-            max_attempts: The maximum number of attempts to check if Vault is unsealed.
+            timeout: Timeout in seconds.
         """
-        for _ in range(max_attempts):
+        initial_time = time.time()
+        while time.time() - initial_time < timeout:
             if not self.is_sealed():
                 return
             logger.info("Vault is sealed, waiting for unseal")
             time.sleep(2)
-        raise TimeoutError(f"Vault is still sealed after checking {max_attempts} times")
+        raise TimeoutError(f"Vault is still sealed {timeout} seconds")
 
     def unseal(self, unseal_keys: List[str]) -> None:
         """Unseal Vault."""

--- a/src/vault.py
+++ b/src/vault.py
@@ -141,7 +141,7 @@ class Vault:
                     "Failed to enable audit device of type: %s, using path: %s", device_type, path
                 )
             logger.info("Enabled audit device of type: %s, using path: %s", device_type, path)
-        logger.info("Audit device of type: %s, using path: %s already enabled", device_type, path)
+        logger.debug("Audit device of type: %s, using path: %s already enabled", device_type, path)
 
     def configure_approle(self, name: str, cidrs: List[str], policies: List[str]) -> str:
         """Create/update a role within vault associating the supplied policies."""

--- a/src/vault.py
+++ b/src/vault.py
@@ -5,6 +5,7 @@
 """Contains all the specificities to communicate with Vault through its API."""
 
 import logging
+import time
 from typing import List, Tuple
 
 import hvac  # type: ignore[import-untyped]
@@ -46,6 +47,15 @@ class Vault:
     def is_sealed(self) -> bool:
         """Returns whether Vault is sealed."""
         return self._client.sys.is_sealed()
+
+    def wait_for_unseal(self) -> None:
+        """Wait for Vault to be unsealed."""
+        elapsed_time = 0
+        while self.is_sealed() and elapsed_time < 30:
+            logger.info("Vault is sealed, waiting for unseal")
+            time.sleep(5)
+            elapsed_time += 5
+        return
 
     def unseal(self, unseal_keys: List[str]) -> None:
         """Unseal Vault."""

--- a/src/vault.py
+++ b/src/vault.py
@@ -49,13 +49,20 @@ class Vault:
         return self._client.sys.is_sealed()
 
     def wait_for_unseal(self) -> None:
-        """Wait for Vault to be unsealed."""
+        """Waits for Vault to be unsealed.
+
+        Expected to be called after attempting to unseal Vault.
+        If it times out, raises a TimeoutError.
+        """
         elapsed_time = 0
-        while self.is_sealed() and elapsed_time < 30:
+        timeout = 30
+        while elapsed_time < 30:
+            if not self.is_sealed():
+                return
             logger.info("Vault is sealed, waiting for unseal")
-            time.sleep(5)
-            elapsed_time += 5
-        return
+            time.sleep(2)
+            elapsed_time += 2
+        raise TimeoutError(f"Vault is still sealed after waiting for {timeout} seconds")
 
     def unseal(self, unseal_keys: List[str]) -> None:
         """Unseal Vault."""

--- a/src/vault.py
+++ b/src/vault.py
@@ -107,10 +107,16 @@ class Vault:
     def enable_audit_device(self, device_type: str, path: str) -> None:
         """Enable a new audit device at the supplied path."""
         if device_type + "/" not in self._client.sys.list_enabled_audit_devices()["data"].keys():
-            self._client.sys.enable_audit_device(
-                device_type=device_type,
-                options={"file_path": path},
-            )
+            if (
+                self._client.sys.enable_audit_device(
+                    device_type=device_type,
+                    options={"file_path": path},
+                ).status_code
+                != 204
+            ):
+                logger.error(
+                    "Failed to enable audit device of type: %s, using path: %s", device_type, path
+                )
             logger.info("Enabled audit device of type: %s, using path: %s", device_type, path)
 
     def configure_approle(self, name: str, cidrs: List[str], policies: List[str]) -> str:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,6 +4,7 @@
 
 import json
 import unittest
+from itertools import count
 from typing import List
 from unittest.mock import Mock, call, patch
 
@@ -17,19 +18,6 @@ from charm import (
     VaultCharm,
     config_file_content_matches,
 )
-
-
-def infinite_time_values(start=0, step=2):
-    """Generator that returns an infinite sequence of time values.
-
-    Args:
-        start: Initial time value.
-        step: Time step between values.
-    """
-    current_time = start
-    while True:
-        yield current_time
-        current_time += step
 
 
 def read_file(path: str) -> str:
@@ -779,7 +767,7 @@ class TestCharm(unittest.TestCase):
         patch_vault_unseal,
         patch_get_binding,
     ):
-        time_values = infinite_time_values()
+        time_values = count(0, 2)
         patch_time.side_effect = lambda: next(time_values)
         root = self.harness.get_filesystem_root(self.container_name)
         self.harness.add_storage(storage_name="certs", attach=True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -594,10 +594,12 @@ class TestCharm(unittest.TestCase):
     @patch("vault.Vault.is_sealed")
     @patch("vault.Vault.is_initialized")
     @patch("vault.Vault.is_api_available")
+    @patch("vault.Vault.enable_audit_device")
     @patch("ops.model.Container.exec", new=Mock)
     def test_given_config_file_not_pushed_when_config_changed_then_config_file_is_pushed(
         self,
         patch_is_api_available,
+        patch_enable_audit_device,
         patch_is_initialized,
         patch_vault_is_sealed,
         patch_get_binding,
@@ -643,10 +645,12 @@ class TestCharm(unittest.TestCase):
     @patch("vault.Vault.is_sealed")
     @patch("vault.Vault.is_initialized")
     @patch("vault.Vault.is_api_available")
+    @patch("vault.Vault.enable_audit_device")
     @patch("ops.model.Container.exec", new=Mock)
     def test_given_initialization_secret_is_stored_when_config_changed_then_pebble_plan_is_applied(
         self,
         patch_is_api_available,
+        patch_enable_audit_device,
         patch_is_initialized,
         patch_vault_is_sealed,
         patch_get_binding,
@@ -701,10 +705,12 @@ class TestCharm(unittest.TestCase):
     @patch("vault.Vault.is_sealed")
     @patch("vault.Vault.is_initialized")
     @patch("vault.Vault.is_api_available")
+    @patch("vault.Vault.enable_audit_device")
     @patch("ops.model.Container.exec", new=Mock)
     def test_given_initialization_secret_is_stored_when_config_changed_then_status_is_active(
         self,
         patch_is_api_available,
+        patch_enable_audit_device,
         patch_is_initialized,
         patch_vault_is_sealed,
         patch_get_binding,
@@ -747,10 +753,12 @@ class TestCharm(unittest.TestCase):
     @patch("vault.Vault.is_sealed")
     @patch("vault.Vault.is_initialized")
     @patch("vault.Vault.is_api_available")
+    @patch("vault.Vault.enable_audit_device")
     @patch("ops.model.Container.exec", new=Mock)
     def test_given_vault_is_sealed_when_config_changed_then_vault_is_unsealed(
         self,
         patch_is_api_available,
+        patch_enable_audit_device,
         patch_is_initialized,
         patch_vault_is_sealed,
         patch_vault_unseal,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -800,12 +800,12 @@ class TestCharm(unittest.TestCase):
     @patch("vault.Vault.is_sealed")
     @patch("vault.Vault.is_initialized")
     @patch("vault.Vault.is_api_available")
-    @patch("vault.Vault.enable_audit_device")
+    @patch("vault.Vault.enable_audit_device", new=Mock)
+    @patch("vault.Vault.wait_for_unseal", new=Mock)
     @patch("ops.model.Container.exec", new=Mock)
     def test_given_vault_is_sealed_when_config_changed_then_vault_is_unsealed(
         self,
         patch_is_api_available,
-        patch_enable_audit_device,
         patch_is_initialized,
         patch_vault_is_sealed,
         patch_vault_unseal,

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -126,3 +126,33 @@ class TestVault(unittest.TestCase):
         vault.enable_approle_auth()
 
         patch_enable_auth_method.assert_not_called()
+
+    @patch("hvac.api.system_backend.audit.Audit.list_enabled_audit_devices")
+    @patch("hvac.api.system_backend.audit.Audit.enable_audit_device")
+    def test_given_audit_device_is_not_yet_enabled_when_enable_audit_device_then_device_is_enabled(
+        self,
+        patch_enable_audit_device,
+        patch_list_enabled_audit_devices,
+    ):
+        patch_list_enabled_audit_devices.return_value = {"data": {}}
+        vault = Vault(url="http://whatever-url", ca_cert_path="whatever path")
+        vault.enable_audit_device(device_type="file", path="stdout")
+        patch_enable_audit_device.assert_called_once_with(
+            device_type="file", options={"file_path": "stdout"}
+        )
+
+    @patch("hvac.api.system_backend.audit.Audit.list_enabled_audit_devices")
+    @patch("hvac.api.system_backend.audit.Audit.enable_audit_device")
+    def test_given_audit_device_already_enabled_when_enable_audit_device_then_method_not_called(
+        self,
+        patch_enable_audit_device,
+        patch_list_enabled_audit_devices,
+    ):
+        patch_list_enabled_audit_devices.return_value = {
+            "data": {
+                "file/": {"options": {"file_path": "stdout"}, "path": "file/", "type": "file"}
+            }
+        }
+        vault = Vault(url="http://whatever-url", ca_cert_path="whatever path")
+        vault.enable_audit_device(device_type="file", path="stdout")
+        patch_enable_audit_device.assert_not_called()

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -3,24 +3,12 @@
 # See LICENSE file for licensing details.
 
 import unittest
+from itertools import count
 from unittest.mock import Mock, call, patch
 
 import requests
 
 from vault import Vault
-
-
-def infinite_time_values(start=0, step=2):
-    """Generator that returns an infinite sequence of time values.
-
-    Args:
-        start: Initial time value.
-        step: Time step between values.
-    """
-    current_time = start
-    while True:
-        yield current_time
-        current_time += step
 
 
 class TestVault(unittest.TestCase):
@@ -178,7 +166,7 @@ class TestVault(unittest.TestCase):
         patch_time,
         patch_is_sealed,
     ):
-        time_values = infinite_time_values()
+        time_values = count(0, 2)
         patch_time.side_effect = lambda: next(time_values)
 
         vault = Vault(url="http://whatever-url", ca_cert_path="whatever path")
@@ -195,7 +183,7 @@ class TestVault(unittest.TestCase):
         patch_time,
         patch_is_sealed,
     ):
-        time_values = infinite_time_values()
+        time_values = count(0, 2)
         patch_time.side_effect = lambda: next(time_values)
 
         vault = Vault(url="http://whatever-url", ca_cert_path="whatever path")


### PR DESCRIPTION
# Description

Enables audit device upon initialisation of Vault

Adds unit tests.
Fixes tests.
Fixes tox issues.
Bumps lib patch to publish change from [this merged pr](https://github.com/canonical/vault-k8s-operator/commit/c5a7608a3619f739ac6449aea39e60a40c32ca3a#diff-e441c2125fb9fd9548dec33cc23c5d2cf968aa96e7b516a2c5f1045148470593R123).

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
