### PR TITLE
chore: Adds discourse Charmhub docs

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,6 +17,7 @@ description: |
 website: https://charmhub.io/vault-k8s
 source: https://github.com/canonical/vault-k8s-operator
 issues: https://github.com/canonical/vault-k8s-operator/issues
+docs: https://discourse.charmhub.io/t/vault-operator-kubernetes/12123
 
 containers:
   vault:


### PR DESCRIPTION
# Description

Adds discourse Charmhub docs pointing to:
- https://discourse.charmhub.io/t/vault-operator-kubernetes/12123

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
