### PR TITLE
feat: Adds integration tests for Vault KV integration

### DIFF
--- a/tests/integration/vault_kv_requirer_operator/actions.yaml
+++ b/tests/integration/vault_kv_requirer_operator/actions.yaml
@@ -1,0 +1,21 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+create-secret:
+  description: Creates a secret in Vault
+  params:
+    key:
+      description: The key to create
+      type: string
+    value:
+      description: The value to create
+      type: string
+  required: [key, value]
+
+get-secret:
+  description: Gets a secret from Vault
+  params:
+    key:
+      description: The key to get
+      type: string
+  required: [key]

--- a/tests/integration/vault_kv_requirer_operator/charmcraft.yaml
+++ b/tests/integration/vault_kv_requirer_operator/charmcraft.yaml
@@ -13,9 +13,5 @@ bases:
 
 parts:
   charm:
-    build-packages:
-      - cargo
-      - libffi-dev
-      - libssl-dev
-      - pkg-config
-      - rustc
+    charm-binary-python-packages:
+      - pydantic

--- a/tests/integration/vault_kv_requirer_operator/charmcraft.yaml
+++ b/tests/integration/vault_kv_requirer_operator/charmcraft.yaml
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+type: "charm"
+bases:
+  - build-on:
+    - name: "ubuntu"
+      channel: "22.04"
+    run-on:
+    - name: "ubuntu"
+      channel: "22.04"
+
+parts:
+  charm:
+    build-packages:
+      - cargo
+      - libffi-dev
+      - libssl-dev
+      - pkg-config
+      - rustc

--- a/tests/integration/vault_kv_requirer_operator/metadata.yaml
+++ b/tests/integration/vault_kv_requirer_operator/metadata.yaml
@@ -1,0 +1,22 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: vault-kv-requirer
+
+display-name: Vault KV Requirer
+summary: Vault KV Requirer
+description: Vault KV Requirer
+
+assumes:
+  - juju >= 3.1
+  - k8s-api
+
+requires:
+  vault-kv:
+    interface: vault-kv
+    limit: 1
+
+storage:
+  certs:
+    type: filesystem
+    minimum-size: 5M

--- a/tests/integration/vault_kv_requirer_operator/requirements.txt
+++ b/tests/integration/vault_kv_requirer_operator/requirements.txt
@@ -2,5 +2,3 @@ ops~=2.8.0
 hvac
 pydantic
 pytest-interface-tester
-requests
-jsonschema

--- a/tests/integration/vault_kv_requirer_operator/requirements.txt
+++ b/tests/integration/vault_kv_requirer_operator/requirements.txt
@@ -1,0 +1,6 @@
+ops~=2.8.0
+hvac
+pydantic
+pytest-interface-tester
+requests
+jsonschema

--- a/tests/integration/vault_kv_requirer_operator/src/charm.py
+++ b/tests/integration/vault_kv_requirer_operator/src/charm.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import secrets
+from pathlib import Path
+from typing import Optional
+
+from charms.vault_k8s.v0.vault_kv import (
+    VaultKvConnectedEvent,
+    VaultKvReadyEvent,
+    VaultKvRequires,
+)
+from ops.charm import ActionEvent, CharmBase, InstallEvent
+from ops.main import main
+from ops.model import ActiveStatus, SecretNotFoundError
+from vault_client import Vault  # type: ignore[import-not-found]
+
+NONCE_SECRET_LABEL = "vault-kv-nonce"
+VAULT_KV_SECRET_LABEL = "vault-kv"
+VAULT_KV_SECRET_PATH = "test"
+VAULT_CA_CERT_FILENAME = "ca.pem"
+
+
+logger = logging.getLogger(__name__)
+
+
+class VaultKVRequirerCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.vault_kv = VaultKvRequires(self, "vault-kv", mount_suffix="kv")
+        self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.vault_kv.on.connected, self._on_kv_connected)
+        self.framework.observe(self.vault_kv.on.ready, self._on_kv_ready)
+        self.framework.observe(self.on.create_secret_action, self._on_create_secret_action)
+        self.framework.observe(self.on.get_secret_action, self._on_get_secret_action)
+
+    def _on_install(self, event: InstallEvent):
+        """Create a secret to store the nonce."""
+        self.unit.add_secret(
+            {"nonce": secrets.token_hex(16)},
+            label=NONCE_SECRET_LABEL,
+            description="Nonce for vault-kv relation",
+        )
+        self.unit.status = ActiveStatus()
+
+    def _on_kv_connected(self, event: VaultKvConnectedEvent):
+        """Request credentials from Vault KV."""
+        relation = self.model.get_relation(event.relation_name, event.relation_id)
+        if not relation:
+            return
+        binding = self.model.get_binding(relation)
+        if not binding:
+            logger.error("Binding not found")
+            return
+        egress_subnet = str(binding.network.interfaces[0].subnet)
+        self.vault_kv.request_credentials(relation, egress_subnet, self.get_nonce())
+
+    def _on_kv_ready(self, event: VaultKvReadyEvent):
+        """Store the Vault KV credentials in a secret."""
+        relation = self.model.get_relation(event.relation_name, event.relation_id)
+        if relation is None:
+            return
+        ca_certificate = self.vault_kv.get_ca_certificate(relation)
+        if not ca_certificate:
+            logger.error("CA certificate not found")
+            return
+        vault_url = self.vault_kv.get_vault_url(relation)
+        if not vault_url:
+            logger.error("Vault URL not found")
+            return
+        mount = self.vault_kv.get_mount(relation)
+        if not mount:
+            logger.error("Mount not found")
+            return
+        unit_credentials = self.vault_kv.get_unit_credentials(relation)
+        secret = self.model.get_secret(id=unit_credentials)
+        secret_content = secret.get_content()
+        juju_secret_content = {
+            "vault-url": vault_url,
+            "mount": mount,
+            "role-id": secret_content["role-id"],
+            "role-secret-id": secret_content["role-secret-id"],
+        }
+        try:
+            vault_kv_secret = self.model.get_secret(label=VAULT_KV_SECRET_LABEL)
+            vault_kv_secret.set_content(content=juju_secret_content)
+            logger.info("Vault KV secret updated")
+        except SecretNotFoundError:
+            self.app.add_secret(juju_secret_content, label=VAULT_KV_SECRET_LABEL)
+            logger.info("Vault KV secret created")
+        self._store_ca_certificate(cert=ca_certificate)
+
+    def _store_ca_certificate(self, cert: str) -> None:
+        """Store the CA certificate in the charm storage."""
+        certs_path = self._get_ca_cert_location_in_charm()
+        with open(f"{certs_path}/{VAULT_CA_CERT_FILENAME}", "w") as fd:
+            fd.write(cert)
+
+    def _on_create_secret_action(self, event: ActionEvent):
+        """Create a secret in Vault KV."""
+        try:
+            secret = self.model.get_secret(label=VAULT_KV_SECRET_LABEL)
+        except SecretNotFoundError:
+            event.fail("Vault KV secret not found")
+            return
+        secret_content = secret.get_content()
+        mount = secret_content["mount"]
+        ca_certificate_path = self._get_ca_cert_location_in_charm()
+        if ca_certificate_path is None:
+            event.fail("CA certificate not found")
+            return
+        secret_key = event.params.get("key")
+        secret_value = event.params.get("value")
+        if not secret_key or not secret_value:
+            event.fail("Missing key or value")
+            return
+        vault = Vault(
+            url=secret_content["vault-url"],
+            approle_role_id=secret_content["role-id"],
+            ca_certificate=f"{ca_certificate_path}/{VAULT_CA_CERT_FILENAME}",
+            approle_secret_id=secret_content["role-secret-id"],
+        )
+        vault.create_secret_in_kv(
+            path=VAULT_KV_SECRET_PATH, mount=mount, key=secret_key, value=secret_value
+        )
+
+    def _on_get_secret_action(self, event: ActionEvent) -> None:
+        try:
+            secret = self.model.get_secret(label=VAULT_KV_SECRET_LABEL)
+        except SecretNotFoundError:
+            event.fail("Vault KV secret not found")
+            return
+        secret_content = secret.get_content()
+        mount = secret_content["mount"]
+        ca_certificate_path = self._get_ca_cert_location_in_charm()
+        if ca_certificate_path is None:
+            event.fail("CA certificate not found")
+            return
+        secret_key = event.params.get("key")
+        if not secret_key:
+            event.fail("Missing key or value")
+            return
+        vault = Vault(
+            url=secret_content["vault-url"],
+            approle_role_id=secret_content["role-id"],
+            ca_certificate=f"{ca_certificate_path}/{VAULT_CA_CERT_FILENAME}",
+            approle_secret_id=secret_content["role-secret-id"],
+        )
+        vault_secret = vault.get_secret_in_kv(path=VAULT_KV_SECRET_PATH, mount=mount)
+        if secret_key not in vault_secret:
+            event.fail("Secret not found")
+            return
+        event.set_results({"value": vault_secret[secret_key]})
+
+    def get_nonce(self) -> str:
+        """Get the nonce from the secret."""
+        secret = self.model.get_secret(label=NONCE_SECRET_LABEL)
+        return secret.get_content()["nonce"]
+
+    def _get_ca_cert_location_in_charm(self) -> Optional[Path]:
+        """Returns the CA certificate location in the charm (not in the workload).
+
+        This path would typically be: /var/lib/juju/storage/certs/0/ca.pem
+
+        Returns:
+            Path: The CA certificate location
+
+        Raises:
+            VaultCertsError: If the CA certificate is not found
+        """
+        storage = self.model.storages
+        if "certs" not in storage:
+            return None
+        if len(storage["certs"]) == 0:
+            return None
+        cert_storage = storage["certs"][0]
+        return cert_storage.location
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main(VaultKVRequirerCharm)

--- a/tests/integration/vault_kv_requirer_operator/src/charm.py
+++ b/tests/integration/vault_kv_requirer_operator/src/charm.py
@@ -59,19 +59,15 @@ class VaultKVRequirerCharm(CharmBase):
 
     def _on_kv_ready(self, event: VaultKvReadyEvent):
         """Store the Vault KV credentials in a secret."""
-        relation = self.model.get_relation(event.relation_name, event.relation_id)
-        if relation is None:
+        if (relation := self.model.get_relation(event.relation_name, event.relation_id)) is None:
             return
-        ca_certificate = self.vault_kv.get_ca_certificate(relation)
-        if not ca_certificate:
+        if not (ca_certificate := self.vault_kv.get_ca_certificate(relation)):
             logger.error("CA certificate not found")
             return
-        vault_url = self.vault_kv.get_vault_url(relation)
-        if not vault_url:
+        if not (vault_url := self.vault_kv.get_vault_url(relation)):
             logger.error("Vault URL not found")
             return
-        mount = self.vault_kv.get_mount(relation)
-        if not mount:
+        if not (mount := self.vault_kv.get_mount(relation)):
             logger.error("Mount not found")
             return
         unit_credentials = self.vault_kv.get_unit_credentials(relation)

--- a/tests/integration/vault_kv_requirer_operator/src/vault_client.py
+++ b/tests/integration/vault_kv_requirer_operator/src/vault_client.py
@@ -1,0 +1,35 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import hvac  # type: ignore[import-untyped]
+
+logger = logging.getLogger(__name__)
+
+
+class Vault:
+    def __init__(
+        self, url: str, ca_certificate: str, approle_role_id: str, approle_secret_id: str
+    ):
+        self._client = hvac.Client(url=url, verify=ca_certificate)
+        self._approle_login(approle_role_id, approle_secret_id)
+
+    def _approle_login(self, role_id: str, secret_id: str) -> None:
+        """Login to Vault using AppRole."""
+        login_response = self._client.auth.approle.login(
+            role_id=role_id, secret_id=secret_id, use_token=False
+        )
+        self._client.token = login_response["auth"]["client_token"]
+
+    def create_secret_in_kv(self, path: str, mount: str, key: str, value: str) -> None:
+        """Create a secret in Vault KV."""
+        self._client.secrets.kv.v2.create_or_update_secret(
+            path=path, secret=dict(data={key: value}), mount_point=mount
+        )
+        logger.info("Secret %s created in mount %s", key, mount)
+
+    def get_secret_in_kv(self, path: str, mount: str) -> dict:
+        """Get a secret from Vault KV."""
+        response = self._client.secrets.kv.v2.read_secret(path=path, mount_point=mount)
+        return response["data"]["data"]["data"]


### PR DESCRIPTION
# Description

This PR introduces a Vault KV requirer charm used in the integration tests to validate the `vault_kv` integration. The requirer charm uses the `vault_kv` library to ask Vault for a new secret mount and creates/get secrets on this mount using Juju actions.

## Rationale

It is currently hard to validate that code changes do not impact the vault_kv integration as requirers are in other projects (ex. Openstack). With these new tests here we can increase confidence that vault code changes do not impact the integration.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
