### PR TITLE
fix: Use fqdn instead of IP address to connect to vault

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -298,7 +298,7 @@ class VaultCharm(CharmBase):
             self._push_ca_certificate_to_workload(certificate=ca_certificate)
         if not self._unit_certificate_pushed_to_workload():
             ca_private_key, ca_certificate = self._get_ca_certificate_secret_in_peer_relation()
-            sans_ip = [self._bind_address, self._ingress_address]
+            sans_ip = [self._ingress_address]
             private_key, certificate = generate_vault_unit_certificate(
                 subject=self._ingress_address,
                 sans_ip=sans_ip,
@@ -593,11 +593,10 @@ class VaultCharm(CharmBase):
 
     @property
     def _api_address(self) -> str:
-        """Returns the API address.
+        """Returns the FQDN with the https schema and vault port.
 
-        Example: "https://1.2.3.4:8200"
-        """
-        return f"https://{self._bind_address}:{self.VAULT_PORT}"
+        Example: "https://vault-k8s-1.vault-k8s-endpoints.test.svc.cluster.local:8200"""
+        return f"https://{socket.getfqdn()}:{self.VAULT_PORT}"
 
     def _push_ca_certificate_to_workload(self, certificate: str) -> None:
         """Push the CA certificate to the workload.

--- a/src/charm.py
+++ b/src/charm.py
@@ -595,7 +595,8 @@ class VaultCharm(CharmBase):
     def _api_address(self) -> str:
         """Returns the FQDN with the https schema and vault port.
 
-        Example: "https://vault-k8s-1.vault-k8s-endpoints.test.svc.cluster.local:8200"""
+        Example: "https://vault-k8s-1.vault-k8s-endpoints.test.svc.cluster.local:8200"
+        """
         return f"https://{socket.getfqdn()}:{self.VAULT_PORT}"
 
     def _push_ca_certificate_to_workload(self, certificate: str) -> None:

--- a/tests/unit/config.hcl
+++ b/tests/unit/config.hcl
@@ -16,7 +16,7 @@ default_lease_ttl = "168h"
 max_lease_ttl     = "720h"
 disable_mlock     = true
 cluster_addr      = "https://1.2.3.4:8201"
-api_addr          = "https://1.2.3.4:8200"
+api_addr          = "https://myhostname:8200"
 telemetry {
   disable_hostname = true
   prometheus_retention_time = "12h"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -407,7 +407,7 @@ class TestCharm(unittest.TestCase):
 
         patch_generate_unit_certificate.assert_called_with(
             subject=ingress_address,
-            sans_ip=[bind_address, ingress_address],
+            sans_ip=[ingress_address],
             sans_dns=[fqdn],
             ca_certificate=ca_certificate.encode(),
             ca_private_key=ca_private_key.encode(),
@@ -421,6 +421,7 @@ class TestCharm(unittest.TestCase):
     @patch("vault.Vault.is_sealed", new=Mock)
     @patch("vault.Vault.is_initialized", new=Mock)
     @patch("vault.Vault.is_api_available", new=Mock)
+    @patch("socket.getfqdn")
     @patch("charm.generate_vault_unit_certificate")
     @patch("charm.generate_vault_ca_certificate")
     @patch("ops.model.Model.get_binding")
@@ -429,9 +430,11 @@ class TestCharm(unittest.TestCase):
         patch_get_binding,
         patch_generate_ca_certificate,
         patch_generate_unit_certificate,
+        patch_socket_getfqdn,
     ):
         patch_generate_ca_certificate.return_value = "ca private key", "ca certificate"
         patch_generate_unit_certificate.return_value = "unit private key", "unit certificate"
+        patch_socket_getfqdn.return_value = "myhostname"
         root = self.harness.get_filesystem_root(self.container_name)
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)


### PR DESCRIPTION
Fixes #69 by using the FQDN to connect to the vault instance instead of using the IP address.

Using the IP address caused an issue because the IP address would change after a crash or removal of a pod. In turn, this would cause the TLS certificate to no longer be valid, as the TLS certificate is validated against the new IP address (but was only issued for the old IP address). We could re-issue the certificate, but the certificate is also valid for anything which uses the same FQDN which the new pod will share.

This change removes the IP address from the certificate, and relies on the FQDN instead.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
