### PR TITLE
chore: Don't use `self` where it's not necessary

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -226,8 +226,8 @@ class TestVaultK8s:
         ca_certificate = action_output["ca-certificate"]
         with open("ca_file.txt", mode="w+") as ca_file:
             ca_file.write(ca_certificate)
-        self._client = hvac.Client(url=vault_endpoint, verify=abspath(ca_file.name))
-        response = self._client.sys.read_health_status()
+        client = hvac.Client(url=vault_endpoint, verify=abspath(ca_file.name))
+        response = client.sys.read_health_status()
         # As we have multiple Vault units, the one who gives the response could be in active or standby.  # noqa: E501, W505
         # According to the Vault upstream code, expected response codes could be "200"
         # if the unit is active or "429" if the unit is standby.


### PR DESCRIPTION
Using `self` isn't necessary here

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
