### PR TITLE
fix: Raft clustering uses hostnames instead of IP addresses

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -336,8 +336,8 @@ class VaultCharm(CharmBase):
         if not self._container.can_connect():
             return
         try:
-            root_token, unseal_keys = self._get_initialization_secret_from_peer_relation()
-            if self._bind_address:
+            root_token, _ = self._get_initialization_secret_from_peer_relation()
+            if self._api_address:
                 vault = Vault(
                     url=self._api_address, ca_cert_path=self._get_ca_cert_location_in_charm()
                 )
@@ -599,6 +599,14 @@ class VaultCharm(CharmBase):
         """
         return f"https://{socket.getfqdn()}:{self.VAULT_PORT}"
 
+    @property
+    def _cluster_address(self) -> str:
+        """Returns the FQDN with the https schema and vault cluster port.
+
+        Example: "https://vault-k8s-1.vault-k8s-endpoints.test.svc.cluster.local:8201"
+        """
+        return f"https://{socket.getfqdn()}:{self.VAULT_CLUSTER_PORT}"
+
     def _push_ca_certificate_to_workload(self, certificate: str) -> None:
         """Push the CA certificate to the workload.
 
@@ -641,7 +649,7 @@ class VaultCharm(CharmBase):
         content = render_vault_config_file(
             default_lease_ttl=self.model.config["default_lease_ttl"],
             max_lease_ttl=self.model.config["max_lease_ttl"],
-            cluster_address=f"https://{self._bind_address}:{self.VAULT_CLUSTER_PORT}",
+            cluster_address=self._cluster_address,
             api_address=self._api_address,
             tcp_address=f"[::]:{self.VAULT_PORT}",
             tls_cert_file=TLS_CERT_FILE_PATH,

--- a/src/charm.py
+++ b/src/charm.py
@@ -336,8 +336,8 @@ class VaultCharm(CharmBase):
         if not self._container.can_connect():
             return
         try:
-            root_token, _ = self._get_initialization_secret_from_peer_relation()
-            if self._api_address:
+            root_token, unseal_keys = self._get_initialization_secret_from_peer_relation()
+            if self._bind_address:
                 vault = Vault(
                     url=self._api_address, ca_cert_path=self._get_ca_cert_location_in_charm()
                 )

--- a/tests/unit/config.hcl
+++ b/tests/unit/config.hcl
@@ -15,7 +15,7 @@ listener "tcp" {
 default_lease_ttl = "168h"
 max_lease_ttl     = "720h"
 disable_mlock     = true
-cluster_addr      = "https://1.2.3.4:8201"
+cluster_addr      = "https://myhostname:8201"
 api_addr          = "https://myhostname:8200"
 telemetry {
   disable_hostname = true


### PR DESCRIPTION
# Description

By using hostnames instead of IP addresses in Vault's `cluster_address`, we make it possible for Vault units to crash and come back up with different IP's. Now we should be able to confidently delete any pod in the cluster and have Vault stay alive.

Before this PR:
```
guillaume@potiron:~$ vault operator raft list-peers
Node               Address             State       Voter
----               -------             -----       -----
dev-vault-k8s/0    10.1.182.18:8201    leader      true
dev-vault-k8s/1    10.1.182.57:8201    follower    true
dev-vault-k8s/2    10.1.182.45:8201    follower    true
```

After this PR:
```
guillaume@potiron:~$ vault operator raft list-peers
Node               Address                                                       State       Voter
----               -------                                                       -----       -----
vau-vault-k8s/0    vault-k8s-0.vault-k8s-endpoints.vau.svc.cluster.local:8201    leader      true
vau-vault-k8s/2    vault-k8s-2.vault-k8s-endpoints.vau.svc.cluster.local:8201    follower    true
vau-vault-k8s/1    vault-k8s-1.vault-k8s-endpoints.vau.svc.cluster.local:8201    follower    true
```

You can see that hostnames are used for clustering now instead of IP's. This can also be observed looking at the autopilot state. Now units go back to alive/healthy once they come back up and the address is their hostname:
```
guillaume@potiron:~$ vault operator raft autopilot state
Healthy:                      true
Failure Tolerance:            1
Leader:                       vau-vault-k8s/2
Voters:
   vau-vault-k8s/2
   vau-vault-k8s/0
   vau-vault-k8s/1
Servers:
   vau-vault-k8s/0
      Name:            vau-vault-k8s/0
      Address:         vault-k8s-0.vault-k8s-endpoints.vau.svc.cluster.local:8201
      Status:          voter
      Node Status:     alive
      Healthy:         true
      Last Contact:    4.621017169s
      Last Term:       4
      Last Index:      107
   vau-vault-k8s/1
      Name:            vau-vault-k8s/1
      Address:         vault-k8s-1.vault-k8s-endpoints.vau.svc.cluster.local:8201
      Status:          voter
      Node Status:     alive
      Healthy:         true
      Last Contact:    2.814981697s
      Last Term:       4
      Last Index:      107
   vau-vault-k8s/2
      Name:            vau-vault-k8s/2
      Address:         vault-k8s-2.vault-k8s-endpoints.vau.svc.cluster.local:8201
      Status:          leader
      Node Status:     alive
      Healthy:         true
      Last Contact:    0s
      Last Term:       4
      Last Index:      107
``` 

Fixes #88 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
