### PR TITLE
chore: Bumps to ops 2.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cosl
-ops~=2.8.0
+ops~=2.9.0
 hvac
 jinja2
 jsonschema


### PR DESCRIPTION
# Description

Bumps to ops 2.9.0. This required some changes in our tests. More specifically, "in 2.9 Harness does the same permission check as Juju whereas previously it would allow a non-leader unit to manage app secrets (this fails if you do it in prod)." (taken from a conversation with @tonyandrewmeyer ).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
