### PR TITLE
fix: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ ck0i0h3q457c7bgte4kg:
     [...]
 ```
 
-Copy the CA certificate content into a file and set the `VAULT_CAPATH` environment variable to reference this file:
+Copy the CA certificate content into a file and set the `VAULT_CACERT` environment variable to reference this file:
 
 ```bash
-export VAULT_CAPATH=/path/to/vault_ca.pem
+export VAULT_CACERT=/path/to/vault_ca.pem
 ```
 
 Identify the vault address by setting the `VAULT_ADDR` environment variable using the Vault URL which is retrieved through `show-proxied-endpoints` action.


### PR DESCRIPTION
I was looking over [this](https://developer.hashicorp.com/vault/docs/commands#vault_cacert) last week, and noticed that CAPATH if for directories and CACERT is for files, even though CAPATH also works for single CA files. We should probably use the one for single files if the tutorial wants us to use a single file.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
