### PR TITLE
chore: Bumps Vault version to 1.15.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ juju integrate vault-k8s:metrics-endpoint prometheus-k8s:metrics-endpoint
 
 ## OCI Images
 
-- Vault: ghcr.io/canonical/vault:1.15.2
+- Vault: ghcr.io/canonical/vault:1.15.3
 
 <!-- LINKS -->
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -36,7 +36,7 @@ resources:
   vault-image:
     type: oci-image
     description: OCI image for Vault
-    upstream-source: ghcr.io/canonical/vault:1.15.2
+    upstream-source: ghcr.io/canonical/vault:1.15.3
 
 storage:
   vault-raft:


### PR DESCRIPTION
# Description

Bumps the Vault rock version to 1.15.3.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
