### PR TITLE
fix: Freezes macaroonbakery==1.3.2 to avoid protobuf error

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -17,3 +17,4 @@ types-PyYAML
 types-setuptools
 types-toml
 types-requests
+macaroonbakery==1.3.2


### PR DESCRIPTION
# Description

Our unit tests and integration tests were failing because of an update in `macaroonbakery`, used by the `juju` package. 

```
TypeError: Descriptors cannot be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
