### PR TITLE
chore: Bumps vault OCI version to 1.15.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ For more information including guides, integrations, configuration options, see 
 
 ## OCI Images
 
-- Vault: ghcr.io/canonical/vault:1.15.3
+- Vault: ghcr.io/canonical/vault:1.15.4

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -36,7 +36,7 @@ resources:
   vault-image:
     type: oci-image
     description: OCI image for Vault
-    upstream-source: ghcr.io/canonical/vault:1.15.3
+    upstream-source: ghcr.io/canonical/vault:1.15.4
 
 storage:
   vault-raft:


### PR DESCRIPTION
# Description

Now that Vault 1.15.4 is available and published, here we update the k8s operator to use it. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
