### PR TITLE
feat: Adds actions to set unseal keys and root token

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -28,3 +28,25 @@ restore-backup:
       description: >-
         Root token to use for unsealing the Vault after the restore.
   required: [backup-id, unseal-keys, root-token]
+
+set-unseal-keys:
+  description: >-
+    Sets unseal keys for Vault.
+    Used to recover Vault if Vault's unseal key and the one used by the charm mismatch for some reason.
+  params:
+    unseal-keys:
+      type: array
+      description: >-
+        Unseal keys to set.
+  required: [unseal-keys]
+
+set-root-token:
+  description: >-
+    Sets root token for Vault.
+    Used to recover Vault if Vault's root token and the one used by the charm mismatch for some reason.
+  params:
+    root-token:
+      type: string
+      description: >-
+        Root token to set.
+  required: [root-token]

--- a/src/charm.py
+++ b/src/charm.py
@@ -253,6 +253,7 @@ class VaultCharm(CharmBase):
         self.framework.observe(self.on.list_backups_action, self._on_list_backups_action)
         self.framework.observe(self.on.restore_backup_action, self._on_restore_backup_action)
         self.framework.observe(self.on.set_unseal_keys_action, self._on_set_unseal_keys_action)
+        self.framework.observe(self.on.set_root_token_action, self._on_set_root_token_action)
         self.framework.observe(
             self.vault_kv.on.new_vault_kv_client_attached, self._on_new_vault_kv_client_attached
         )
@@ -631,7 +632,7 @@ class VaultCharm(CharmBase):
         """Handles set-unseal-keys action.
 
         Updates the initialization secret in the peer relation
-            with the provided root token.
+            with the provided unseal keys.
 
         Args:
             event: ActionEvent


### PR DESCRIPTION
# Description

Adds actions to set unseal keys and root token, these actions can be useful to recover the charm if the unseal key of vault changes while the one stored in the juju secret doesn't get updated or gets updated incorrectly.
Adds unit tests


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
