### PR TITLE
chore: Publishes charm to 1.15 track

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -33,7 +33,7 @@ jobs:
           built-charm-path: ${{ inputs.charm-file-name }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: latest/edge
+          channel: 1.15/edge
       - name: Publish libs
         uses: canonical/charming-actions/release-libraries@2.4.0
         with:


### PR DESCRIPTION
# Description

Publishes charm to 1.15 track.

Merge will be blocked until track is created.
https://discourse.charmhub.io/t/requesting-track-1-15-for-vault-k8s-operator/13055

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
