### PR TITLE
chore: Rename vault lib to vault_client

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -17,7 +17,7 @@ from hvac.exceptions import VaultError  # type: ignore[import-untyped]
 from requests.exceptions import RequestException
 
 # The unique Charmhub library identifier, never change it
-LIBID = "4bf272a4aa314f6397b1823e198f2291"
+LIBID = "674754a3268d4507b749ec34214706fd"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0


### PR DESCRIPTION
According to https://github.com/canonical/charmcraft/issues/214, charm library renaming is not yet supported. 

So, this renames the library by providing a new `LIBID`. that was created with the correct name.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
