### PR TITLE
fix: Pins version of pydantic as required by ingress.py

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ jinja2
 jsonschema
 lightkube
 lightkube-models
-pydantic
+pydantic<2.0
 pytest-interface-tester
 pyhcl
 requests


### PR DESCRIPTION
# Description

The ingress lib (`ingress.py`) requires `pydantic` to be <2.
This PR pins the version.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
