### PR TITLE
test: Fix for integration test

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -277,7 +277,7 @@ class TestVaultK8s:
         # 472: {{Description: "data recovery mode replication secondary and active"}}
         # 501: {{Description: "not initialized"}}
         # 503: {{Description: "sealed"}}
-        assert str(response) == "<Response [200]>" or "<Response [429]>"
+        assert response.status_code in (200, 429)
         os.remove("ca_file.txt")
 
     async def test_given_vault_kv_requirer_deployed_when_vault_kv_relation_created_then_status_is_active(


### PR DESCRIPTION
Use `in` operator so that logic is applied correctly. Previous code would always return true.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
