### PR TITLE
feat: add requirer side of pki integration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 options:
@@ -11,3 +11,9 @@ options:
     type: string
     default: "720h"
     description: Specifies the maximum possible lease duration for Vault's tokens and secrets.
+  common_name:
+    type: string
+    default: "vault"
+    description: |
+      The common name that will be used by Vault as an intermediate CA. This will only be used when the charm is 
+      configured to use a Vault PKI backend through the `vault-pki` relation.

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -1488,10 +1488,10 @@ class TLSCertificatesRequiresV3(Object):
         Returns:
             list: List of RequirerCSR objects.
         """
-        requirer_csrs = []
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
-            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
+            return []
+        requirer_csrs = []
         requirer_relation_data = _load_relation_data(relation.data[self.model.unit])
         requirer_csrs_dict = requirer_relation_data.get("certificate_signing_requests", [])
         for requirer_csr_dict in requirer_csrs_dict:
@@ -1676,8 +1676,6 @@ class TLSCertificatesRequiresV3(Object):
         Returns:
             List: List[ProviderCertificate]
         """
-        if not self.model.get_relation(self.relationship_name):
-            return []
         assigned_certificates = []
         for requirer_csr in self.get_certificate_signing_requests(fulfilled_only=True):
             if cert := self._find_certificate_in_relation_data(requirer_csr.csr):

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -312,7 +312,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1676,6 +1676,8 @@ class TLSCertificatesRequiresV3(Object):
         Returns:
             List: List[ProviderCertificate]
         """
+        if not self.model.get_relation(self.relationship_name):
+            return []
         assigned_certificates = []
         for requirer_csr in self.get_certificate_signing_requests(fulfilled_only=True):
             if cert := self._find_certificate_in_relation_data(requirer_csr.csr):

--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -125,7 +125,7 @@ class Vault:
             path=name,
         )
 
-    def enable_pki_engine(self, *, path: str):
+    def enable_pki_engine(self, path: str):
         """Ensure a PKI mount is enabled."""
         self._client.sys.enable_secrets_engine(
             backend_type="pki",
@@ -134,16 +134,16 @@ class Vault:
         )
         logger.info("Enabled PKI backend")
 
-    def is_secret_engine_enabled(self, *, path: str) -> bool:
+    def is_secret_engine_enabled(self, path: str) -> bool:
         """Check if a PKI mount is enabled."""
         return path + "/" in self._client.sys.list_mounted_secrets_engines()
 
-    def is_intermediate_ca_set(self, *, mount: str, certificate: str) -> bool:
+    def is_intermediate_ca_set(self, mount: str, certificate: str) -> bool:
         """Check if the intermediate CA is set for the PKI backend."""
         intermediate_ca = self._client.secrets.pki.read_ca_certificate(mount_point=mount)
         return intermediate_ca == certificate
 
-    def is_intermediate_ca_set_with_common_name(self, *, mount: str, common_name: str) -> bool:
+    def is_intermediate_ca_set_with_common_name(self, mount: str, common_name: str) -> bool:
         """Check if the intermediate CA is set for the PKI backend."""
         intermediate_ca = self._client.secrets.pki.read_ca_certificate(mount_point=mount)
         if not intermediate_ca:

--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -154,20 +154,18 @@ class Vault:
         )[0].value
         return existing_common_name == common_name
 
-    def configure_pki_intermediate_ca(self, mount: str, common_name: str) -> str:
-        """Create an intermediate CA for the PKI backend.
-
-        Generate a CSR for the intermediate CA.
+    def generate_pki_intermediate_ca_csr(self, mount: str, common_name: str) -> str:
+        """Generate an intermediate CA CSR for the PKI backend.
 
         Returns:
-            The CSR.
+            str: The Certificate Signing Request.
         """
         response = self._client.secrets.pki.generate_intermediate(
             mount_point=mount,
             common_name=common_name,
             type="internal",
         )
-        logger.info("Generated a intermediate CA CSR for the PKI backend")
+        logger.info("Generated a intermediate CA for the PKI backend")
         return response["data"]["csr"]
 
     def set_pki_intermediate_ca_certificate(self, certificate: str, mount: str) -> None:
@@ -182,7 +180,7 @@ class Vault:
         existing_certificate = self._client.secrets.pki.read_ca_certificate(mount_point=mount)
         return existing_certificate == certificate
 
-    def set_pki_charm_role(self, role: str, allowed_domains: str, mount: str) -> None:
+    def create_pki_charm_role(self, role: str, allowed_domains: str, mount: str) -> None:
         """Create a role for the PKI backend."""
         self._client.secrets.pki.create_or_update_role(
             name=role,
@@ -194,8 +192,8 @@ class Vault:
         )
         logger.info("Created a role for the PKI backend")
 
-    def is_pki_role_set(self, role: str, mount: str) -> bool:
-        """Check if the role is set for the PKI backend."""
+    def is_pki_role_created(self, role: str, mount: str) -> bool:
+        """Check if the role is created for the PKI backend."""
         try:
             existing_roles = self._client.secrets.pki.list_roles(mount_point=mount)
             return role in existing_roles["data"]["keys"]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -80,5 +80,11 @@ requires:
     description: |
       Communication between the vault units and from a client to Vault should 
       be done using the certificates provided by this integration.
+  tls-certificates-pki:
+    interface: tls-certificates
+    limit: 1
+    description: |
+      Interface to be used to provide Vault with its CA certificate. Vault will
+      use this certificate to sign the certificates it issues on the `vault-pki` interface.
   s3-parameters:
     interface: s3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,6 @@ copyright-check = "True"
 copyright-author = "Canonical Ltd."
 copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
 
-[lint.mccabe]
-max-complexity = 10
-
 [tool.codespell]
 skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ copyright-check = "True"
 copyright-author = "Canonical Ltd."
 copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
 
-[tool.ruff.mccabe]
+[lint.mccabe]
 max-complexity = 10
 
 [tool.codespell]

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,6 +21,10 @@ from charms.observability_libs.v1.kubernetes_service_patch import (
     ServicePort,
 )
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
+from charms.tls_certificates_interface.v3.tls_certificates import (
+    CertificateAvailableEvent,
+    TLSCertificatesRequiresV3,
+)
 from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 from charms.vault_k8s.v0.vault_client import Vault
 from charms.vault_k8s.v0.vault_kv import NewVaultKvClientAttachedEvent, VaultKvProvides
@@ -33,6 +37,7 @@ from ops.charm import (
     CharmBase,
     ConfigChangedEvent,
     InstallEvent,
+    RelationJoinedEvent,
     RemoveEvent,
 )
 from ops.main import main
@@ -55,13 +60,17 @@ CONFIG_TEMPLATE_NAME = "vault.hcl.j2"
 VAULT_CONFIG_FILE_PATH = "/vault/config/vault.hcl"
 PEER_RELATION_NAME = "vault-peers"
 KV_RELATION_NAME = "vault-kv"
+TLS_CERTIFICATES_PKI_RELATION_NAME = "tls-certificates-pki"
 KV_SECRET_PREFIX = "kv-creds-"
 VAULT_INITIALIZATION_SECRET_LABEL = "vault-initialization"
+PKI_CSR_SECRET_LABEL = "pki-csr"
 S3_RELATION_NAME = "s3-parameters"
 REQUIRED_S3_PARAMETERS = ["bucket", "access-key", "secret-key", "endpoint"]
 BACKUP_KEY_PREFIX = "vault-backup"
 CONTAINER_TLS_FILE_DIRECTORY_PATH = "/vault/certs"
 CONTAINER_NAME = "vault"
+PKI_MOUNT = "charm-pki"
+PKI_ROLE = "charm"
 
 
 class VaultCharm(CharmBase):
@@ -79,6 +88,9 @@ class VaultCharm(CharmBase):
             ports=[ServicePort(name="vault", port=self.VAULT_PORT)],
         )
         self.vault_kv = VaultKvProvides(self, KV_RELATION_NAME)
+        self.tls_certificates_pki = TLSCertificatesRequiresV3(
+            self, TLS_CERTIFICATES_PKI_RELATION_NAME
+        )
         self._metrics_endpoint = MetricsEndpointProvider(
             self,
             jobs=[
@@ -117,6 +129,14 @@ class VaultCharm(CharmBase):
         self.framework.observe(self.on.set_root_token_action, self._on_set_root_token_action)
         self.framework.observe(
             self.vault_kv.on.new_vault_kv_client_attached, self._on_new_vault_kv_client_attached
+        )
+        self.framework.observe(
+            self.on.tls_certificates_pki_relation_joined,
+            self._on_tls_certificates_pki_relation_joined,
+        )
+        self.framework.observe(
+            self.tls_certificates_pki.on.certificate_available,
+            self._on_tls_certificate_pki_certificate_available,
         )
 
     def _on_install(self, event: InstallEvent):
@@ -179,6 +199,8 @@ class VaultCharm(CharmBase):
         if vault.is_active() and not vault.audit_device_enabled(device_type="file", path="stdout"):
             vault.enable_audit_device(device_type="file", path="stdout")
         self._set_peer_relation_node_api_address()
+        self._configure_pki_secrets_engine()
+        self._add_ca_certificate_to_pki_secrets_engine()
         self.tls.send_ca_cert()
         if vault.is_active() and not vault.is_raft_cluster_healthy():
             # Log if a raft node starts reporting unhealthy
@@ -257,7 +279,8 @@ class VaultCharm(CharmBase):
         vault.enable_approle_auth()
         mount = "charm-" + relation.app.name + "-" + event.mount_suffix
         self._set_kv_relation_data(relation, mount, ca_certificate)
-        vault.configure_kv_mount(mount)
+        if not vault.is_secret_engine_enabled(path=mount):
+            vault.enable_kv_engine(mount)
         for unit in relation.units:
             egress_subnet = relation.data[unit].get("egress_subnet")
             nonce = relation.data[unit].get("nonce")
@@ -269,6 +292,95 @@ class VaultCharm(CharmBase):
                 continue
             self._ensure_unit_credentials(vault, relation, unit.name, mount, nonce, egress_subnet)
             self._remove_stale_nonce(relation=relation, nonce=nonce)
+
+    def _on_tls_certificates_pki_relation_joined(self, _: RelationJoinedEvent) -> None:
+        """Handle the tls-certificates-pki relation joined event."""
+        self._configure_pki_secrets_engine()
+
+    def _configure_pki_secrets_engine(self) -> None:
+        """Configure the PKI secrets engine."""
+        if not self.unit.is_leader():
+            logger.debug("Only leader unit can handle a vault-pki certificate request, skipping")
+            return
+        if not self._is_peer_relation_created():
+            logger.debug("Peer relation not created")
+            return
+        vault = self._get_initialized_vault_client()
+        if not vault:
+            logger.debug("Failed to get initialized Vault")
+            return
+        if not self._tls_certificates_pki_relation_created():
+            logger.debug("TLS Certificates PKI relation not created, skipping")
+            return
+        common_name = self._get_config_common_name()
+        if not common_name:
+            logger.error("Common name is not set in the charm config, skipping")
+            return
+        if not vault.is_secret_engine_enabled(path=PKI_MOUNT):
+            vault.enable_pki_engine(path=PKI_MOUNT)
+        if not vault.is_intermediate_ca_set_with_common_name(
+            mount=PKI_MOUNT, common_name=common_name
+        ):
+            csr = vault.configure_pki_intermediate_ca(mount=PKI_MOUNT, common_name=common_name)
+            self.tls_certificates_pki.request_certificate_creation(
+                certificate_signing_request=csr.encode(),
+                is_ca=True,
+            )
+            self._set_pki_csr_secret_in_peer_relation(csr)
+
+    def _add_ca_certificate_to_pki_secrets_engine(self) -> None:
+        """Add the CA certificate to the PKI secrets engine."""
+        if not self.unit.is_leader():
+            logger.debug("Only leader unit can handle a vault-pki certificate request")
+            return
+        if not self._is_peer_relation_created():
+            logger.debug("Peer relation not created")
+            return
+        vault = self._get_initialized_vault_client()
+        if not vault:
+            logger.debug("Failed to get initialized Vault")
+            return
+        common_name = self._get_config_common_name()
+        if not common_name:
+            logger.error("Common name is not set in the charm config")
+            return
+        certificate = self._get_pki_ca_certificate()
+        if not certificate:
+            logger.debug("No certificate available")
+            return
+        if not vault.is_intermediate_ca_set(mount=PKI_MOUNT, certificate=certificate):
+            vault.set_pki_intermediate_ca_certificate(certificate=certificate, mount=PKI_MOUNT)
+        if not vault.is_pki_role_set(role=PKI_ROLE, mount=PKI_MOUNT):
+            vault.set_pki_charm_role(
+                allowed_domains=common_name,
+                mount=PKI_MOUNT,
+                role=PKI_ROLE,
+            )
+
+    def _get_pki_ca_certificate(self) -> str:
+        """Return the PKI CA certificate provided by the TLS provider.
+
+        Validate that the CSR matches the one in the peer relation.
+        """
+        assigned_certificates = self.tls_certificates_pki.get_assigned_certificates()
+        if not assigned_certificates:
+            return ""
+        if not self._pki_csr_secret_set_in_peer_relation():
+            logger.info("PKI CSR not set in the peer relation")
+            return ""
+        pki_csr = self._get_pki_csr_secret_in_peer_relation()
+        if not pki_csr:
+            logger.warning("PKI CSR not found in the peer relation")
+            return ""
+        for assigned_certificate in assigned_certificates:
+            if assigned_certificate.csr == pki_csr:
+                return assigned_certificate.certificate
+        logger.info("No certificate matches the PKI CSR in the peer relation")
+        return ""
+
+    def _on_tls_certificate_pki_certificate_available(self, event: CertificateAvailableEvent):
+        """Handle the tls-certificates-pki certificate available event."""
+        self._add_ca_certificate_to_pki_secrets_engine()
 
     def _on_create_backup_action(self, event: ActionEvent) -> None:
         """Handle the create-backup action.
@@ -784,6 +896,34 @@ class VaultCharm(CharmBase):
         secret.set_content(content=juju_secret_content)
         peer_relation.data[self.app].update({"vault-initialization-secret-id": secret.id})  # type: ignore[union-attr]
 
+    def _set_pki_csr_secret_in_peer_relation(self, csr: str) -> None:
+        if not self._is_peer_relation_created():
+            raise RuntimeError("Peer relation not created")
+        juju_secret_content = {"csr": csr}
+        peer_relation = self.model.get_relation(PEER_RELATION_NAME)
+        if not self._pki_csr_secret_set_in_peer_relation():
+            juju_secret = self.app.add_secret(juju_secret_content, label=PKI_CSR_SECRET_LABEL)
+            peer_relation.data[self.app].update({"vault-pki-csr-secret-id": juju_secret.id})  # type: ignore[union-attr]
+            return
+        secret = self.model.get_secret(label=PKI_CSR_SECRET_LABEL)
+        secret.set_content(content=juju_secret_content)
+        peer_relation.data[self.app].update({"vault-pki-csr-secret-id": secret.id})  # type: ignore[union-attr]
+
+    def _get_pki_csr_secret_in_peer_relation(self) -> Optional[str]:
+        """Return the PKI CSR secret from the peer relation."""
+        if not self._pki_csr_secret_set_in_peer_relation():
+            raise RuntimeError("PKI CSR secret not set in peer relation")
+        secret = self.model.get_secret(label=PKI_CSR_SECRET_LABEL)
+        return secret.get_content()["csr"]
+
+    def _pki_csr_secret_set_in_peer_relation(self) -> bool:
+        """Return whether PKI CSR secret is stored in peer relation data."""
+        try:
+            self.model.get_secret(label=PKI_CSR_SECRET_LABEL)
+            return True
+        except SecretNotFoundError:
+            return False
+
     def _get_initialization_secret_from_peer_relation(self) -> Tuple[str, List[str]]:
         """Get the vault initialization secret from the peer relation.
 
@@ -824,6 +964,10 @@ class VaultCharm(CharmBase):
     def _is_peer_relation_created(self) -> bool:
         """Check if the peer relation is created."""
         return bool(self.model.get_relation(PEER_RELATION_NAME))
+
+    def _tls_certificates_pki_relation_created(self) -> bool:
+        """Check if the TLS Certificates PKI relation is created."""
+        return self._is_relation_created(TLS_CERTIFICATES_PKI_RELATION_NAME)
 
     def _is_relation_created(self, relation_name: str) -> bool:
         """Check if the relation is created.
@@ -1034,6 +1178,10 @@ class VaultCharm(CharmBase):
             for node_api_address in self._get_peer_relation_node_api_addresses()
             if node_api_address != self._api_address
         ]
+
+    def _get_config_common_name(self) -> str:
+        """Return the common name to use for the PKI backend."""
+        return self.config.get("common_name", "")
 
     @property
     def _node_id(self) -> str:

--- a/src/charm.py
+++ b/src/charm.py
@@ -321,7 +321,7 @@ class VaultCharm(CharmBase):
         if not vault.is_intermediate_ca_set_with_common_name(
             mount=PKI_MOUNT, common_name=common_name
         ):
-            csr = vault.configure_pki_intermediate_ca(mount=PKI_MOUNT, common_name=common_name)
+            csr = vault.generate_pki_intermediate_ca_csr(mount=PKI_MOUNT, common_name=common_name)
             self.tls_certificates_pki.request_certificate_creation(
                 certificate_signing_request=csr.encode(),
                 is_ca=True,
@@ -350,8 +350,8 @@ class VaultCharm(CharmBase):
             return
         if not vault.is_intermediate_ca_set(mount=PKI_MOUNT, certificate=certificate):
             vault.set_pki_intermediate_ca_certificate(certificate=certificate, mount=PKI_MOUNT)
-        if not vault.is_pki_role_set(role=PKI_ROLE, mount=PKI_MOUNT):
-            vault.set_pki_charm_role(
+        if not vault.is_pki_role_created(role=PKI_ROLE, mount=PKI_MOUNT):
+            vault.create_pki_charm_role(
                 allowed_domains=common_name,
                 mount=PKI_MOUNT,
                 role=PKI_ROLE,

--- a/src/charm.py
+++ b/src/charm.py
@@ -357,26 +357,26 @@ class VaultCharm(CharmBase):
                 role=PKI_ROLE,
             )
 
-    def _get_pki_ca_certificate(self) -> str:
+    def _get_pki_ca_certificate(self) -> Optional[str]:
         """Return the PKI CA certificate provided by the TLS provider.
 
         Validate that the CSR matches the one in the peer relation.
         """
         assigned_certificates = self.tls_certificates_pki.get_assigned_certificates()
         if not assigned_certificates:
-            return ""
+            return None
         if not self._pki_csr_secret_set_in_peer_relation():
             logger.info("PKI CSR not set in the peer relation")
-            return ""
+            return None
         pki_csr = self._get_pki_csr_secret_in_peer_relation()
         if not pki_csr:
             logger.warning("PKI CSR not found in the peer relation")
-            return ""
+            return None
         for assigned_certificate in assigned_certificates:
             if assigned_certificate.csr == pki_csr:
                 return assigned_certificate.certificate
         logger.info("No certificate matches the PKI CSR in the peer relation")
-        return ""
+        return None
 
     def _on_tls_certificate_pki_certificate_available(self, event: CertificateAvailableEvent):
         """Handle the tls-certificates-pki certificate available event."""

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -432,3 +432,18 @@ class TestVaultK8s:
             timeout=1000,
             wait_for_exact_units=NUM_VAULT_UNITS,
         )
+
+    @pytest.mark.abort_on_fail
+    async def test_given_tls_certificates_pki_relation_when_integrate_then_status_is_active(
+        self, ops_test: OpsTest
+    ):
+        assert ops_test.model
+        await ops_test.model.integrate(
+            relation1=f"{APPLICATION_NAME}:tls-certificates-pki",
+            relation2=f"{SELF_SIGNED_CERTIFICATES_APPLICATION_NAME}:certificates",
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[APPLICATION_NAME, SELF_SIGNED_CERTIFICATES_APPLICATION_NAME],
+            status="active",
+            timeout=1000,
+        )

--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_client.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_client.py
@@ -7,6 +7,7 @@ from unittest.mock import call, patch
 
 import requests
 from charms.vault_k8s.v0.vault_client import Vault
+from tls import generate_ca, generate_private_key  # type: ignore[import-not-found]
 
 
 class TestVault(unittest.TestCase):
@@ -199,3 +200,35 @@ class TestVault(unittest.TestCase):
         }
         vault = Vault(url="http://whatever-url", ca_cert_path="whatever path")
         self.assertFalse(vault.audit_device_enabled(device_type=device_type, path=path))
+
+    @patch("hvac.api.secrets_engines.pki.Pki.read_ca_certificate")
+    def test_given_ca_common_name_matches_when_is_intermediate_ca_set_with_common_name_then_return_true(
+        self, patch_read_ca_certificate
+    ):
+        common_name = "whatever.com"
+        private_key = generate_private_key()
+        ca_certificate = generate_ca(private_key=private_key, subject=common_name)
+        patch_read_ca_certificate.return_value = ca_certificate
+        vault = Vault(url="http://whatever-url", ca_cert_path="whatever path")
+
+        is_set = vault.is_intermediate_ca_set_with_common_name(
+            mount="PKI_MOUNT", common_name=common_name
+        )
+
+        self.assertTrue(is_set)
+
+    @patch("hvac.api.secrets_engines.pki.Pki.read_ca_certificate")
+    def test_given_ca_common_name_does_not_match_when_is_intermediate_ca_set_with_common_name_then_return_false(  # noqa: E501
+        self, patch_read_ca_certificate
+    ):
+        common_name = "whatever.com"
+        private_key = generate_private_key()
+        ca_certificate = generate_ca(private_key=private_key, subject="WRONG SUBJECT")
+        patch_read_ca_certificate.return_value = ca_certificate
+        vault = Vault(url="http://whatever-url", ca_cert_path="whatever path")
+
+        is_set = vault.is_intermediate_ca_set_with_common_name(
+            mount="PKI_MOUNT", common_name=common_name
+        )
+
+        self.assertFalse(is_set)

--- a/tests/unit/lib/charms/vault_k8s/v0/tls.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/tls.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from datetime import datetime, timedelta
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+def generate_private_key() -> str:
+    """Generate a private key.
+
+    Args:
+        password (bytes): Password for decrypting the private key
+        key_size (int): Key size in bytes
+        public_exponent: Public exponent.
+
+    Returns:
+        bytes: Private Key
+    """
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+    key_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return key_bytes.decode("utf-8")
+
+
+def generate_ca(private_key: str, subject: str) -> str:
+    """Generate a CA Certificate.
+
+    Args:
+        private_key (str): Private key
+        subject (str): Certificate subject
+
+    Returns:
+        bytes: CA Certificate.
+    """
+    private_key_object = serialization.load_pem_private_key(private_key.encode(), password=None)
+    subject_name = x509.Name(
+        [
+            x509.NameAttribute(x509.NameOID.COUNTRY_NAME, "US"),
+            x509.NameAttribute(x509.NameOID.COMMON_NAME, subject),
+        ]
+    )
+    subject_identifier_object = x509.SubjectKeyIdentifier.from_public_key(
+        private_key_object.public_key()  # type: ignore[arg-type]
+    )
+    subject_identifier = key_identifier = subject_identifier_object.public_bytes()
+    key_usage = x509.KeyUsage(
+        digital_signature=True,
+        key_encipherment=True,
+        key_cert_sign=True,
+        key_agreement=False,
+        content_commitment=False,
+        data_encipherment=False,
+        crl_sign=False,
+        encipher_only=False,
+        decipher_only=False,
+    )
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject_name)
+        .issuer_name(subject_name)
+        .public_key(private_key_object.public_key())  # type: ignore[arg-type]
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.utcnow())
+        .not_valid_after(datetime.utcnow() + timedelta(days=365))
+        .add_extension(x509.SubjectKeyIdentifier(digest=subject_identifier), critical=False)
+        .add_extension(
+            x509.AuthorityKeyIdentifier(
+                key_identifier=key_identifier,
+                authority_cert_issuer=None,
+                authority_cert_serial_number=None,
+            ),
+            critical=False,
+        )
+        .add_extension(key_usage, critical=True)
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None),
+            critical=True,
+        )
+        .sign(private_key_object, hashes.SHA256())  # type: ignore[arg-type]
+    )
+
+    cert_bytes = cert.public_bytes(serialization.Encoding.PEM)
+    return cert_bytes.decode("utf-8")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2019,7 +2019,7 @@ class TestCharm(unittest.TestCase):
     @patch(f"{TLS_CERTIFICATES_LIB_PATH}.TLSCertificatesRequiresV3.request_certificate_creation")
     @patch("charms.vault_k8s.v0.vault_client.Vault.enable_pki_engine")
     @patch("charms.vault_k8s.v0.vault_client.Vault.is_secret_engine_enabled")
-    @patch("charms.vault_k8s.v0.vault_client.Vault.configure_pki_intermediate_ca")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.generate_pki_intermediate_ca_csr")
     @patch("charms.vault_k8s.v0.vault_client.Vault.is_intermediate_ca_set_with_common_name")
     @patch("charms.vault_k8s.v0.vault_client.Vault.is_api_available")
     @patch("charms.vault_k8s.v0.vault_client.Vault.is_initialized")
@@ -2028,7 +2028,7 @@ class TestCharm(unittest.TestCase):
         patch_is_initialized,
         patch_is_api_available,
         patch_is_intermediate_ca_set_with_common_name,
-        patch_configure_pki_intermediate_ca,
+        patch_generate_pki_intermediate_ca_csr,
         patch_is_secret_engine_enabled,
         patch_enable_pki_engine,
         patch_request_certificate_creation,
@@ -2037,7 +2037,7 @@ class TestCharm(unittest.TestCase):
         patch_is_initialized.return_value = True
         patch_is_api_available.return_value = True
         patch_is_intermediate_ca_set_with_common_name.return_value = False
-        patch_configure_pki_intermediate_ca.return_value = csr
+        patch_generate_pki_intermediate_ca_csr.return_value = csr
         patch_is_secret_engine_enabled.return_value = False
         self.harness.set_leader(is_leader=True)
         self.harness.set_can_connect(container=self.container_name, val=True)
@@ -2057,7 +2057,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation_unit(relation_id, "tls-provider/0")
 
         patch_enable_pki_engine.assert_called_with(path="charm-pki")
-        patch_configure_pki_intermediate_ca.assert_called_with(
+        patch_generate_pki_intermediate_ca_csr.assert_called_with(
             mount="charm-pki", common_name="vault"
         )
         patch_request_certificate_creation.assert_called_with(
@@ -2065,8 +2065,8 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch(f"{TLS_CERTIFICATES_LIB_PATH}.TLSCertificatesRequiresV3.get_assigned_certificates")
-    @patch("charms.vault_k8s.v0.vault_client.Vault.set_pki_charm_role")
-    @patch("charms.vault_k8s.v0.vault_client.Vault.is_pki_role_set")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.create_pki_charm_role")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.is_pki_role_created")
     @patch("charms.vault_k8s.v0.vault_client.Vault.set_pki_intermediate_ca_certificate")
     @patch("charms.vault_k8s.v0.vault_client.Vault.is_intermediate_ca_set")
     @patch("charms.vault_k8s.v0.vault_client.Vault.is_api_available")
@@ -2077,8 +2077,8 @@ class TestCharm(unittest.TestCase):
         patch_is_api_available,
         patch_is_intermediate_ca_set,
         patch_set_pki_intermediate_ca_certificate,
-        patch_is_pki_role_set,
-        patch_set_pki_charm_role,
+        patch_is_pki_role_created,
+        patch_create_pki_charm_role,
         patch_get_assigned_certificates,
     ):
         csr = "some csr content"
@@ -2088,7 +2088,7 @@ class TestCharm(unittest.TestCase):
         patch_is_initialized.return_value = True
         patch_is_api_available.return_value = True
         patch_is_intermediate_ca_set.return_value = False
-        patch_is_pki_role_set.return_value = False
+        patch_is_pki_role_created.return_value = False
         self.harness.set_leader(is_leader=True)
         self.harness.set_can_connect(container=self.container_name, val=True)
         self.harness.add_storage(storage_name="certs", attach=True)
@@ -2130,6 +2130,6 @@ class TestCharm(unittest.TestCase):
             certificate=certificate,
             mount="charm-pki",
         )
-        patch_set_pki_charm_role.assert_called_with(
+        patch_create_pki_charm_role.assert_called_with(
             allowed_domains="vault", mount="charm-pki", role="charm"
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,10 +13,15 @@ import requests
 from botocore.exceptions import BotoCoreError, ClientError, ConnectTimeoutError
 from botocore.response import StreamingBody
 from charm import (
+    PKI_CSR_SECRET_LABEL,
     S3_RELATION_NAME,
     VAULT_INITIALIZATION_SECRET_LABEL,
     VaultCharm,
     config_file_content_matches,
+)
+from charms.tls_certificates_interface.v3.tls_certificates import (
+    CertificateAvailableEvent,
+    ProviderCertificate,
 )
 from charms.vault_k8s.v0.vault_tls import CA_CERTIFICATE_JUJU_SECRET_LABEL
 from ops import testing
@@ -24,7 +29,9 @@ from ops.model import ActiveStatus, WaitingStatus
 
 S3_LIB_PATH = "charms.data_platform_libs.v0.s3"
 VAULT_KV_LIB_PATH = "charms.vault_k8s.v0.vault_kv"
+TLS_CERTIFICATES_LIB_PATH = "charms.tls_certificates_interface.v3.tls_certificates"
 VAULT_KV_RELATION_NAME = "vault-kv"
+TLS_CERTIFICATES_PKI_RELATION_NAME = "tls-certificates-pki"
 VAULT_KV_REQUIRER_APPLICATION_NAME = "vault-kv-requirer"
 
 
@@ -129,6 +136,25 @@ class TestCharm(unittest.TestCase):
             secret.set_info(label=VAULT_INITIALIZATION_SECRET_LABEL)
             self.harness.set_leader(original_leader_state)
         key_values = {"vault-initialization-secret-id": secret_id}
+        self.harness.update_relation_data(
+            app_or_unit=self.app_name,
+            relation_id=relation_id,
+            key_values=key_values,
+        )
+
+    def _set_csr_secret_in_peer_relation(self, relation_id: int, csr: str) -> None:
+        """Set the csr secret in the peer relation."""
+        content = {
+            "csr": csr,
+        }
+        original_leader_state = self.harness.charm.unit.is_leader()
+        with self.harness.hooks_disabled():
+            self.harness.set_leader(is_leader=True)
+            secret_id = self.harness.add_model_secret(owner=self.app_name, content=content)
+            secret = self.harness.model.get_secret(id=secret_id)
+            secret.set_info(label=PKI_CSR_SECRET_LABEL)
+            self.harness.set_leader(original_leader_state)
+        key_values = {"vault-pki-csr-secret-id": secret_id}
         self.harness.update_relation_data(
             app_or_unit=self.app_name,
             relation_id=relation_id,
@@ -1807,7 +1833,8 @@ class TestCharm(unittest.TestCase):
     @patch("charms.vault_k8s.v0.vault_client.Vault.is_initialized", new=Mock)
     @patch("charms.vault_k8s.v0.vault_client.Vault.is_api_available", new=Mock)
     @patch("charms.vault_k8s.v0.vault_client.Vault.set_token", new=Mock)
-    @patch("charms.vault_k8s.v0.vault_client.Vault.configure_kv_mount", new=Mock)
+    @patch("charms.vault_k8s.v0.vault_client.Vault.is_secret_engine_enabled", new=Mock)
+    @patch("charms.vault_k8s.v0.vault_client.Vault.enable_kv_engine", new=Mock)
     @patch("charms.vault_k8s.v0.vault_client.Vault.configure_kv_policy", new=Mock)
     @patch("charms.vault_k8s.v0.vault_client.Vault.generate_role_secret_id")
     @patch("charms.vault_k8s.v0.vault_client.Vault.configure_approle")
@@ -1851,7 +1878,8 @@ class TestCharm(unittest.TestCase):
     @patch("charms.vault_k8s.v0.vault_client.Vault.is_api_available", new=Mock)
     @patch("charms.vault_k8s.v0.vault_client.Vault.set_token", new=Mock)
     @patch("charms.vault_k8s.v0.vault_client.Vault.enable_approle_auth", new=Mock)
-    @patch("charms.vault_k8s.v0.vault_client.Vault.configure_kv_mount", new=Mock)
+    @patch("charms.vault_k8s.v0.vault_client.Vault.is_secret_engine_enabled", new=Mock)
+    @patch("charms.vault_k8s.v0.vault_client.Vault.enable_kv_engine", new=Mock)
     @patch("charms.vault_k8s.v0.vault_client.Vault.configure_kv_policy", new=Mock)
     @patch("charms.vault_k8s.v0.vault_client.Vault.generate_role_secret_id")
     @patch("charms.vault_k8s.v0.vault_client.Vault.configure_approle")
@@ -1899,7 +1927,8 @@ class TestCharm(unittest.TestCase):
     @patch("charms.vault_k8s.v0.vault_client.Vault.is_api_available", new=Mock)
     @patch("charms.vault_k8s.v0.vault_client.Vault.set_token", new=Mock)
     @patch("charms.vault_k8s.v0.vault_client.Vault.enable_approle_auth", new=Mock)
-    @patch("charms.vault_k8s.v0.vault_client.Vault.configure_kv_mount", new=Mock)
+    @patch("charms.vault_k8s.v0.vault_client.Vault.is_secret_engine_enabled", new=Mock)
+    @patch("charms.vault_k8s.v0.vault_client.Vault.enable_kv_engine", new=Mock)
     @patch("charms.vault_k8s.v0.vault_client.Vault.configure_kv_policy", new=Mock)
     @patch("charms.vault_k8s.v0.vault_client.Vault.is_initialized", new=Mock)
     @patch("charms.vault_k8s.v0.vault_client.Vault.read_role_secret")
@@ -1947,15 +1976,18 @@ class TestCharm(unittest.TestCase):
     @patch("charms.vault_k8s.v0.vault_client.Vault.configure_kv_policy", new=Mock)
     @patch("charms.vault_k8s.v0.vault_client.Vault.generate_role_secret_id")
     @patch("charms.vault_k8s.v0.vault_client.Vault.configure_approle")
-    @patch("charms.vault_k8s.v0.vault_client.Vault.configure_kv_mount")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.is_secret_engine_enabled")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.enable_kv_engine")
     @patch("ops.model.Model.get_binding")
     def test_given_prerequisites_are_met_when_new_vault_kv_client_attached_then_kv_mount_is_configured(
         self,
-        patch_configure_kv_mount,
+        patch_enable_kv_engine,
+        patch_is_secret_engine_enabled,
         patch_get_binding,
         patch_configure_approle,
         patch_generate_role_secret_id,
     ):
+        patch_is_secret_engine_enabled.return_value = False
         patch_get_binding.return_value = MockBinding(
             bind_address="1.2.1.2", ingress_address="10.1.0.1"
         )
@@ -1982,4 +2014,122 @@ class TestCharm(unittest.TestCase):
         event.relation_id = rel_id
         event.mount_suffix = "suffix"
         self.harness.charm._on_new_vault_kv_client_attached(event)
-        patch_configure_kv_mount.assert_called_once()
+        patch_enable_kv_engine.assert_called_once()
+
+    @patch(f"{TLS_CERTIFICATES_LIB_PATH}.TLSCertificatesRequiresV3.request_certificate_creation")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.enable_pki_engine")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.is_secret_engine_enabled")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.configure_pki_intermediate_ca")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.is_intermediate_ca_set_with_common_name")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.is_api_available")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.is_initialized")
+    def test_given_vault_is_available_when_tls_certificates_pki_relation_joined_then_certificate_request_is_made(
+        self,
+        patch_is_initialized,
+        patch_is_api_available,
+        patch_is_intermediate_ca_set_with_common_name,
+        patch_configure_pki_intermediate_ca,
+        patch_is_secret_engine_enabled,
+        patch_enable_pki_engine,
+        patch_request_certificate_creation,
+    ):
+        csr = "some csr content"
+        patch_is_initialized.return_value = True
+        patch_is_api_available.return_value = True
+        patch_is_intermediate_ca_set_with_common_name.return_value = False
+        patch_configure_pki_intermediate_ca.return_value = csr
+        patch_is_secret_engine_enabled.return_value = False
+        self.harness.set_leader(is_leader=True)
+        self.harness.set_can_connect(container=self.container_name, val=True)
+        self.harness.add_storage(storage_name="certs", attach=True)
+        root = self.harness.get_filesystem_root(self.container_name)
+        (root / "vault/certs/ca.pem").write_text("some ca")
+        peer_relation_id = self._set_peer_relation()
+        self._set_initialization_secret_in_peer_relation(
+            relation_id=peer_relation_id,
+            root_token="root token content",
+            unseal_keys=["unseal_keys"],
+        )
+
+        relation_id = self.harness.add_relation(
+            relation_name=TLS_CERTIFICATES_PKI_RELATION_NAME, remote_app="tls-provider"
+        )
+        self.harness.add_relation_unit(relation_id, "tls-provider/0")
+
+        patch_enable_pki_engine.assert_called_with(path="charm-pki")
+        patch_configure_pki_intermediate_ca.assert_called_with(
+            mount="charm-pki", common_name="vault"
+        )
+        patch_request_certificate_creation.assert_called_with(
+            certificate_signing_request=csr.encode(), is_ca=True
+        )
+
+    @patch(f"{TLS_CERTIFICATES_LIB_PATH}.TLSCertificatesRequiresV3.get_assigned_certificates")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.set_pki_charm_role")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.is_pki_role_set")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.set_pki_intermediate_ca_certificate")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.is_intermediate_ca_set")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.is_api_available")
+    @patch("charms.vault_k8s.v0.vault_client.Vault.is_initialized")
+    def test_given_vault_is_available_when_pki_certificate_is_available_then_certificate_added_to_vault_pki(
+        self,
+        patch_is_initialized,
+        patch_is_api_available,
+        patch_is_intermediate_ca_set,
+        patch_set_pki_intermediate_ca_certificate,
+        patch_is_pki_role_set,
+        patch_set_pki_charm_role,
+        patch_get_assigned_certificates,
+    ):
+        csr = "some csr content"
+        certificate = "some certificate"
+        ca = "some ca"
+        chain = [ca]
+        patch_is_initialized.return_value = True
+        patch_is_api_available.return_value = True
+        patch_is_intermediate_ca_set.return_value = False
+        patch_is_pki_role_set.return_value = False
+        self.harness.set_leader(is_leader=True)
+        self.harness.set_can_connect(container=self.container_name, val=True)
+        self.harness.add_storage(storage_name="certs", attach=True)
+        root = self.harness.get_filesystem_root(self.container_name)
+        (root / "vault/certs/ca.pem").write_text("some ca")
+        peer_relation_id = self._set_peer_relation()
+        self._set_initialization_secret_in_peer_relation(
+            relation_id=peer_relation_id,
+            root_token="root token content",
+            unseal_keys=["unseal_keys"],
+        )
+        self._set_csr_secret_in_peer_relation(relation_id=peer_relation_id, csr="some csr content")
+        event = CertificateAvailableEvent(
+            handle=Mock(),
+            certificate=certificate,
+            certificate_signing_request=csr,
+            ca=ca,
+            chain=chain,
+        )
+        relation_id = self.harness.add_relation(
+            relation_name=TLS_CERTIFICATES_PKI_RELATION_NAME, remote_app="tls-provider"
+        )
+
+        patch_get_assigned_certificates.return_value = [
+            ProviderCertificate(
+                relation_id=relation_id,
+                application_name="tls-provider",
+                csr=csr,
+                certificate=certificate,
+                ca=ca,
+                chain=chain,
+                revoked=False,
+            )
+        ]
+
+        self.harness.charm._on_tls_certificate_pki_certificate_available(event=event)
+
+        patch_set_pki_intermediate_ca_certificate.assert_called_with(
+            certificate=certificate,
+            mount="charm-pki",
+        )
+        patch_set_pki_charm_role.assert_called_with(
+            allowed_domains="vault", mount="charm-pki", role="charm"
+        )


### PR DESCRIPTION
# Description

Vault can now act as an intermediate CA where the parent CA is the provider side of the newly added  `tls-certificates-pki` integration. Here we add the requirer side of the `pki` integration .

Upon certificates-pki-request relation joined:
- Configure the PKI mount, configures the PKI intermediate CA (generates a CSR)
- Send that CSR over to the relation provider.
- Store the CSR in a Juju secret

Upon Certificate Available:
- Validate that the received cert matches the stored CSR
- Set the PKI intermediate CA certificate
- Set the PKI charm role

## Notes
- A follow up PR will implement the provider side where requires will be able to integrate with Vault using the `tls-certificates` integration that we will alias to `vault-pki`.
- This PR depends on this PR being merged first: https://github.com/canonical/tls-certificates-interface/pull/119

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
