### PR TITLE
chore: centralize status management

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_tls.py
+++ b/lib/charms/vault_k8s/v0/vault_tls.py
@@ -181,9 +181,9 @@ class VaultTLSManager(Object):
                 ca_private_key, ca_certificate = generate_vault_ca_certificate()
                 self._set_ca_certificate_secret(ca_private_key, ca_certificate)
                 tls_logger.info("Saved the Vault generated CA cert in juju secrets.")
-            if not self._tls_file_pushed_to_workload(
+            if not self.tls_file_pushed_to_workload(
                 File.CA
-            ) or not self._tls_file_pushed_to_workload(File.CERT):
+            ) or not self.tls_file_pushed_to_workload(File.CERT):
                 self._generate_self_signed_certs(subject_ip)
                 tls_logger.info(
                     "Saved Vault generated CA and self signed certificate to %s.",
@@ -361,7 +361,7 @@ class VaultTLSManager(Object):
 
     def ca_certificate_is_saved(self) -> bool:
         """Return wether a CA cert is saved in the charm."""
-        return self.ca_certificate_secret_exists() or self._tls_file_pushed_to_workload(File.CA)
+        return self.ca_certificate_secret_exists() or self.tls_file_pushed_to_workload(File.CA)
 
     def _remove_all_certs_from_workload(self) -> None:
         """Remove the certificate files that are used for authentication."""
@@ -421,7 +421,7 @@ class VaultTLSManager(Object):
             pass
         tls_logger.debug("Removed %s file from workload.", file.name)
 
-    def _tls_file_pushed_to_workload(self, file: File) -> bool:
+    def tls_file_pushed_to_workload(self, file: File) -> bool:
         """Return whether tls file is pushed to the workload.
 
         Args:

--- a/lib/charms/vault_k8s/v0/vault_tls.py
+++ b/lib/charms/vault_k8s/v0/vault_tls.py
@@ -317,6 +317,20 @@ class VaultTLSManager(Object):
         storage_location = cert_storage.location
         return f"{storage_location}/{file.name.lower()}.pem"
 
+    def tls_file_available_in_charm(self, file: File) -> bool:
+        """Return whether the given file is available in the charm.
+
+        Args:
+            file: a File object that determines which file to check
+        Returns:
+            bool: True if file exists
+        """
+        try:
+            self.get_tls_file_path_in_charm(file)
+            return True
+        except VaultCertsError:
+            return False
+
     def _get_ca_certificate_secret(self) -> Tuple[str, str]:
         """Get the vault CA certificate secret.
 

--- a/lib/charms/vault_k8s/v0/vault_tls.py
+++ b/lib/charms/vault_k8s/v0/vault_tls.py
@@ -33,7 +33,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 logger = logging.getLogger(__name__)

--- a/src/charm.py
+++ b/src/charm.py
@@ -182,10 +182,10 @@ class VaultCharm(CharmBase):
             event.add_status(WaitingStatus("Waiting for initialization secret"))
             return
         if not self.tls.tls_file_pushed_to_workload(File.CA):
-            event.add_status(WaitingStatus("Waiting for TLS certificates"))
+            event.add_status(WaitingStatus("Waiting for CA certificate in workload"))
             return
         if not self.tls.tls_file_available_in_charm(File.CA):
-            event.add_status(WaitingStatus("Waiting for CA certificate"))
+            event.add_status(WaitingStatus("Waiting for CA certificate in charm"))
             return
         vault = Vault(
             url=self._api_address, ca_cert_path=self.tls.get_tls_file_path_in_charm(File.CA)

--- a/src/charm.py
+++ b/src/charm.py
@@ -184,6 +184,9 @@ class VaultCharm(CharmBase):
         if not self.tls.tls_file_pushed_to_workload(File.CA):
             event.add_status(WaitingStatus("Waiting for TLS certificates"))
             return
+        if not self.tls.tls_file_available_in_charm(File.CA):
+            event.add_status(WaitingStatus("Waiting for CA certificate"))
+            return
         vault = Vault(
             url=self._api_address, ca_cert_path=self.tls.get_tls_file_path_in_charm(File.CA)
         )

--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_tls.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_tls.py
@@ -114,7 +114,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Model.get_binding")
-    def test_given_not_leader_and_ca_not_set_when_configure_then_status_is_waiting(
+    def test_given_not_leader_and_ca_not_set_when_evaluate_status_then_status_is_waiting(
         self, patch_get_binding
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
@@ -132,11 +132,11 @@ class TestCharm(unittest.TestCase):
             bind_address="1.2.1.2", ingress_address="10.1.0.1"
         )
 
-        self.harness.charm.on.config_changed.emit()
+        self.harness.evaluate_status()
 
         self.assertEqual(
             self.harness.charm.unit.status,
-            WaitingStatus("Waiting for CA certificate to be set."),
+            WaitingStatus("Waiting for CA certificate"),
         )
 
     @patch("charms.vault_k8s.v0.vault_client.Vault.enable_audit_device", new=Mock)


### PR DESCRIPTION
# Description

Centralize status management using the Collect Status event handler from ops. 

## Rationale

As we are adding more event handlers in the context of PKI, it became clear that having central status management would simplify operations. Specifically, without this change here, we would have had to move the charm to blocked status in the `RelationJoined` event in cases where the `common_name` config is not set. That would have been an issue as a follow-up `update_status` event would have overwritten this status. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
