### PR TITLE
chore: Remove repeated section in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,5 @@ allow_redefinition = true
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]
-module = ["charms.*", "ops.*", "kubernetes.*", "flatten_json.*", "git.*"]
-ignore_missing_imports = true
-follow_imports = "silent"
-
-[[tool.mypy.overrides]]
 module = ["charms.*"]
 follow_imports = "silent"


### PR DESCRIPTION
Removes a section that is repeated in `pyproject.toml`

This is an attempt to fix dependabot, which is currently complaining that `pyproject.toml` is not able to be parsed (but I can't find much more details than that).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
