### PR TITLE
chore: Change formatting of pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,10 @@ target-version = ["py38"]
 [tool.ruff]
 extend-exclude = ["__pycache__", "*.egg_info"]
 line-length = 99
-lint.select = ["E", "W", "F", "C", "N", "D", "I001"]
-lint.extend-ignore = [
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
     "D203",
     "D204",
     "D213",
@@ -33,9 +35,11 @@ lint.extend-ignore = [
     "D413",
     "C901",
 ]
-lint.ignore = ["E501", "D107"]
-lint.mccabe.max-complexity = 10
-lint.per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+ignore = ["E501", "D107"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
 
 [tool.flake8]
 max-line-length = 99


### PR DESCRIPTION
For whatever reason, dependabot appears to expect the `pyproject.toml` to be in this format. This should get dependabot working again.

I tested this on my fork.

This same change will be applied to https://github.com/canonical/vault-operator/ upon successful dependabot run.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
