### PR TITLE
chore: bump pydantic to v2.5.3

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ jinja2
 jsonschema
 lightkube
 lightkube-models
-pydantic<2.0
+pydantic==2.5.3
 pytest-interface-tester
 pyhcl
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,17 @@
 #
 #    pip-compile requirements.in
 #
-anyio==4.2.0
+annotated-types==0.6.0
+    # via pydantic
+anyio==4.3.0
     # via httpx
 attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
-boto3==1.34.44
+boto3==1.34.50
     # via -r requirements.in
-botocore==1.34.44
+botocore==1.34.50
     # via
     #   boto3
     #   s3transfer
@@ -33,9 +35,9 @@ cryptography==42.0.3
     # via -r requirements.in
 h11==0.14.0
     # via httpcore
-httpcore==1.0.3
+httpcore==1.0.4
     # via httpx
-httpx==0.26.0
+httpx==0.27.0
     # via lightkube
 hvac==2.1.0
     # via -r requirements.in
@@ -77,10 +79,12 @@ pluggy==1.4.0
     # via pytest
 pycparser==2.21
     # via cffi
-pydantic==1.10.14
+pydantic==2.5.3
     # via
     #   -r requirements.in
     #   pytest-interface-tester
+pydantic-core==2.14.6
+    # via pydantic
 pyhcl==0.4.5
     # via -r requirements.in
 pytest==8.0.2
@@ -111,7 +115,7 @@ s3transfer==0.10.0
     # via boto3
 six==1.16.0
     # via python-dateutil
-sniffio==1.3.0
+sniffio==1.3.1
     # via
     #   anyio
     #   httpx
@@ -121,6 +125,7 @@ typing-extensions==4.9.0
     # via
     #   cosl
     #   pydantic
+    #   pydantic-core
 urllib3==2.0.7
     # via
     #   botocore


### PR DESCRIPTION
# Description

Bump pydantic to v2.5.3.

## Note

Unfortunately we can't go higher at the moment because the `rustc` package from the apt repo for Ubuntu 22.04 used in the Charm isn't compatible. You can read more about this here: https://github.com/pydantic/pydantic-core/issues/1176

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
