### PR TITLE
fix: install traefik from stable channel

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -177,7 +177,7 @@ class TestVaultK8s:
             "traefik-k8s",
             application_name=TRAEFIK_APPLICATION_NAME,
             trust=True,
-            channel="edge",
+            channel="stable",
         )
 
     @pytest.mark.abort_on_fail


### PR DESCRIPTION
# Description

The `vault-k8s` integration tests are flaky and one of the reason is that we are using Traefik from its edge branch. Specifically, we have failing CI's which prevent unrelated changes from being merged. Here we move to use stable instead to hopefully gain some stability. 

## Reference

- Failing CI: https://github.com/canonical/vault-k8s-operator/actions/runs/8145030648/job/22260393500?pr=213

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
