### PR TITLE
feat: Add approle login, and charm policy creation to the Vault client

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -7,7 +7,6 @@ This library shares operations that interact with Vault through its API. It is
 intended to be used by charms that need to manage a Vault cluster.
 """
 
-
 import logging
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
@@ -25,7 +24,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 logger = logging.getLogger(__name__)
@@ -101,6 +100,17 @@ class Vault:
     def set_token(self, token: str) -> None:
         """Set the Vault token for authentication."""
         self._client.token = token
+
+    def approle_login(self, role_id: str, secret_id: str) -> None:
+        """Authenticate to Vault using AppRole."""
+        self._client.auth.approle.login(role_id=role_id, secret_id=secret_id, use_token=True)
+
+    def configure_charm_access_policy(self, name: str) -> None:
+        """Create/update a policy within vault for the charm to access vault."""
+        with open("src/templates/charm_policy.hcl", "r") as f:
+            charm_policy = f.read()
+        self._client.sys.create_or_update_policy(name=name, policy=charm_policy)
+        logger.debug(f"Created charm policy: {name}")
 
     def remove_raft_node(self, node_id: str) -> None:
         """Remove raft peer."""


### PR DESCRIPTION
These are necessary methods to implement manual unseal.

I know that @Kayra1 is working on a bit of a refactor in this class, so I tried to keep this as minimal as possible for now.

See https://github.com/canonical/vault-operator/pull/62 for the downstream dependency / usage.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
