### PR TITLE
fix: Detect if tls file actually exists

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_tls.py
+++ b/lib/charms/vault_k8s/v0/vault_tls.py
@@ -4,6 +4,7 @@
 """This file includes methods to manage TLS certificates within the Vault charms."""
 
 import logging
+import os
 import socket
 from abc import ABC, abstractmethod
 from enum import Enum, auto
@@ -326,8 +327,8 @@ class VaultTLSManager(Object):
             bool: True if file exists
         """
         try:
-            self.get_tls_file_path_in_charm(file)
-            return True
+            file_path = self.get_tls_file_path_in_charm(file)
+            return os.path.exists(file_path)
         except VaultCertsError:
             return False
 

--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_tls.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_tls.py
@@ -9,7 +9,7 @@ from typing import List
 from unittest.mock import Mock, patch
 
 from charm import VAULT_INITIALIZATION_SECRET_LABEL, VaultCharm
-from charms.vault_k8s.v0.vault_tls import CA_CERTIFICATE_JUJU_SECRET_LABEL
+from charms.vault_k8s.v0.vault_tls import CA_CERTIFICATE_JUJU_SECRET_LABEL, File
 from ops import testing
 from ops.model import WaitingStatus
 
@@ -421,3 +421,15 @@ class TestCharm(unittest.TestCase):
         )
 
         self.assertNotIn("ca", relation_data)
+
+    def test_given_ca_cert_is_not_available_when_certificate_written_then_tls_file_available_in_charm_returns_true(
+        self,
+    ):
+        self.harness.add_storage(storage_name="certs", attach=True)
+        root = self.harness.get_filesystem_root(self.container_name)
+
+        assert not self.harness.charm.tls.tls_file_available_in_charm(File.CA)
+
+        (root / "vault/certs/ca.pem").write_text(EXAMPLE_CA)
+
+        assert self.harness.charm.tls.tls_file_available_in_charm(File.CA)


### PR DESCRIPTION
Before this change, the function just checked for the existence of the storage, but didn't check if the file was actually there.

We now ensure that the file actually exists.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
