### PR TITLE
feat: Make CIDRs list optional

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -26,7 +26,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -210,13 +210,15 @@ class Vault:
         )
         logger.debug("Created or updated charm policy: %s", policy_name)
 
-    def configure_approle(self, role_name: str, cidrs: List[str], policies: List[str]) -> str:
+    def configure_approle(
+        self, role_name: str, policies: List[str], cidrs: List[str] | None = None
+    ) -> str:
         """Create/update a role within vault associating the supplied policies.
 
         Args:
             role_name: Name of the role to be created or updated
-            cidrs: The list of IP networks that are allowed to authenticate
             policies: The attached list of policy names this approle will have access to
+            cidrs: The list of IP networks that are allowed to authenticate
         """
         self._client.auth.approle.create_or_update_approle(
             role_name,
@@ -229,7 +231,7 @@ class Vault:
         response = self._client.auth.approle.read_role_id(role_name)
         return response["data"]["role_id"]
 
-    def generate_role_secret_id(self, name: str, cidrs: List[str]) -> str:
+    def generate_role_secret_id(self, name: str, cidrs: List[str] | None = None) -> str:
         """Generate a new secret tied to an AppRole."""
         response = self._client.auth.approle.generate_secret_id(name, cidr_list=cidrs)
         return response["data"]["secret_id"]

--- a/src/charm.py
+++ b/src/charm.py
@@ -778,7 +778,7 @@ class VaultCharm(CharmBase):
         """Ensure a unit has credentials to access the vault-kv mount."""
         policy_name = role_name = mount + "-" + unit_name.replace("/", "-")
         vault.configure_policy(policy_name, "src/templates/kv_mount.hcl", mount)
-        role_id = vault.configure_approle(role_name, [egress_subnet], [policy_name])
+        role_id = vault.configure_approle(role_name, [policy_name], [egress_subnet])
         secret = self._create_or_update_kv_secret(
             vault,
             relation,

--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_client.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_client.py
@@ -181,7 +181,7 @@ class TestVault(unittest.TestCase):
         patch_read_role_id.return_value = {"data": {"role_id": "1234"}}
         vault = Vault(url="http://whatever-url", ca_cert_path="whatever path")
         assert "1234" == vault.configure_approle(
-            "test-approle", ["192.168.1.0/24"], ["root", "default"]
+            "test-approle", ["root", "default"], ["192.168.1.0/24"]
         )
 
         patch_create_approle.assert_called_with(


### PR DESCRIPTION
Make the CIDRs list optional in the vault client calls.

Context: https://github.com/canonical/vault-operator/pull/62#discussion_r1516346734

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
