### PR TITLE
chore: use update status event to sync kv requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
-boto3==1.34.68
+boto3==1.34.69
     # via -r requirements.in
-botocore==1.34.68
+botocore==1.34.69
     # via
     #   boto3
     #   s3transfer

--- a/src/charm.py
+++ b/src/charm.py
@@ -291,6 +291,9 @@ class VaultCharm(CharmBase):
 
     def _on_new_vault_kv_client_attached(self, event: NewVaultKvClientAttachedEvent):
         """Handle vault-kv-client attached event."""
+        if not self.unit.is_leader():
+            logger.debug("Only leader unit can handle a vault-kv request")
+            return
         relation = self.model.get_relation(relation_name=KV_RELATION_NAME, relation_id=event.relation_id)
         if not relation:
             logger.error("Relation not found for relation id %s", event.relation_id)
@@ -311,7 +314,7 @@ class VaultCharm(CharmBase):
     def _configure_pki_secrets_engine(self) -> None:
         """Configure the PKI secrets engine."""
         if not self.unit.is_leader():
-            logger.debug("Only leader unit can handle a vault-pki certificate request, skipping")
+            logger.debug("Only leader unit can handle a vault-pki certificate request")
             return
         vault = self._get_initialized_vault_client()
         if not vault:

--- a/src/charm.py
+++ b/src/charm.py
@@ -423,7 +423,7 @@ class VaultCharm(CharmBase):
             logger.debug("Failed to get initialized Vault")
             return
         vault.enable_approle_auth_method()
-        mount = "charm-" + app_name + "-" + mount_suffix
+        mount = f"charm-{app_name}-{mount_suffix}"
         self._set_kv_relation_data(relation, mount, ca_certificate)
         vault.enable_secrets_engine(SecretsBackend.KV_V2, mount)
         self._ensure_unit_credentials(vault, relation, unit_name, mount, nonce, egress_subnet)

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ commands =
 [testenv:unit]
 description = Run unit tests
 commands =
-    coverage run --source={[vars]src_path} -m pytest {[vars]unit_test_path} -v --tb native -s {posargs}
+    coverage run --source={[vars]src_path},{[vars]lib_path} -m pytest {[vars]unit_test_path} -v --tb native -s {posargs}
     coverage report
 
 [testenv:integration]


### PR DESCRIPTION
# Description

Here we update the `vault_kv` library to make it possible for the charm to get kv requests at any moments using `getters`. The charm uses those getters to sync kv requests on update status events, just like we do for tls certificate requests.

## Rationale
1. Move all relation data logic to the kv library. You won't see any `relation.data.get()` in charm code anymore. It all lives in the `vault_kv` lib, where it belongs.
2. Standardise resource provider approach between tls certificates and kv secrets, both offer pull based mathods allowing to get the outstanding requests at any moment.
3. Get rid of `event.defer()` for kv requests. 
4. This is a major change for the provider side of the lib for which only vault-k8s uses. The intent was to make this change before using it in the machine version of the charm to avoid back and forths. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
