### PR TITLE
fix: tell type checkers that the config options are strings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -11,7 +11,7 @@ import datetime
 import json
 import logging
 import socket
-from typing import IO, Dict, List, Optional, Tuple
+from typing import IO, Dict, List, Optional, Tuple, cast
 
 import hcl
 from botocore.exceptions import BotoCoreError, ClientError, ConnectTimeoutError
@@ -962,8 +962,8 @@ class VaultCharm(CharmBase):
             for node_api_address in self._get_peer_node_api_addresses()
         ]
         content = render_vault_config_file(
-            default_lease_ttl=self.model.config["default_lease_ttl"],
-            max_lease_ttl=self.model.config["max_lease_ttl"],
+            default_lease_ttl=cast(str, self.model.config["default_lease_ttl"]),
+            max_lease_ttl=cast(str, self.model.config["max_lease_ttl"]),
             cluster_address=self._cluster_address,
             api_address=self._api_address,
             tcp_address=f"[::]:{self.VAULT_PORT}",
@@ -1240,7 +1240,7 @@ class VaultCharm(CharmBase):
 
     def _get_config_common_name(self) -> str:
         """Return the common name to use for the PKI backend."""
-        return self.config.get("common_name", "")
+        return cast(str, self.config.get("common_name", ""))
 
     def _common_name_config_is_valid(self) -> bool:
         """Return whether the config value for the common name is valid."""


### PR DESCRIPTION
# Description

ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

This PR adds a `typing.cast` call where the config values are loaded and used where the type should be str.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation N/A
- [ ] I have added tests that validate the behaviour of the software N/A
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules N/A
