### PR TITLE
fix: freeze lxd to 5.20/stable

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -30,6 +30,7 @@ jobs:
           provider: microk8s
           channel: 1.29-strict/stable
           juju-channel: 3.4/stable
+          lxd-channel: 5.20/stable
       - name: Enable Metallb
         if: ${{ inputs.enable-metallb == true }}
         run: /usr/bin/sg snap_microk8s -c "sudo microk8s enable metallb:${{ inputs.metallb-range }}"


### PR DESCRIPTION
# Description

Charmcraft currently does not work with the latest lxd version (5.21/stable). This prevents multiple PR's being merged. This change freezes lxd to 5.20/stable. 

## Reference
- https://github.com/canonical/charmcraft/issues/1640

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
