### PR TITLE
fix: refactor integration tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,54 @@
+name: Build
+
+on:
+  workflow_call:
+
+jobs:
+  build-charm-under-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+    
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+        with:
+            channel: latest/stable
+    
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Build charm under test
+        run: charmcraft pack --verbose
+
+      - name: Archive Charm Under Test
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-charm
+          path: "*.charm"
+          retention-days: 5
+
+  build-kv-requirer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+        with:
+          channel: latest/stable
+      
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Build KV Requirer charm
+        run: |
+          cp lib/charms/vault_k8s/v0/vault_kv.py tests/integration/vault_kv_requirer_operator/lib/charms/vault_k8s/v0/vault_kv.py
+          cd tests/integration/vault_kv_requirer_operator
+          charmcraft pack --verbose
+
+      - name: Archive KV Requirer Charm
+        uses: actions/upload-artifact@v4
+        with:
+          name: kv-requirer-charm
+          path: tests/integration/vault_kv_requirer_operator/*.charm
+          retention-days: 5

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,57 +1,45 @@
-name: Integration tests
+name: Integration Tests
 
 on:
   workflow_call:
-    inputs:
-      charm-file-name:
-        description: Tested charm file name
-        required: true
-        type: string
-      enable-metallb:
-        description: Enable MetalLB
-        required: false
-        type: boolean
-        default: false
-      metallb-range:
-        description: MetalLB range
-        required: false
-        type: string
-        default: "10.0.0.2-10.0.0.10"
 
 jobs:
-  integration-test:
-    runs-on: ubuntu-22.04
+  integration-tests:
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+
+      - name: Fetch Charm Under Test
+        uses: actions/download-artifact@v4
+        with:
+          name: built-charm
+          path: built/
+      
+      - name: Get Charm Under Test Path
+        id: charm-path
+        run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+      
+      - name: Fetch KV Requirer Charm
+        uses: actions/download-artifact@v4
+        with:
+          name: kv-requirer-charm
+          path: kv-requirer/
+      
+      - name: Get KV Requirer Charm Path
+        id: kv-requirer-charm-path
+        run: echo "charm_path=$(find kv-requirer/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+    
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          provider: microk8s
-          channel: 1.29-strict/stable
           juju-channel: 3.4/stable
-          lxd-channel: 5.20/stable
-      - name: Enable Metallb
-        if: ${{ inputs.enable-metallb == true }}
-        run: /usr/bin/sg snap_microk8s -c "sudo microk8s enable metallb:${{ inputs.metallb-range }}"
+          provider: lxd
+
+      - name: Install tox
+        run: pip install tox
+
       - name: Run integration tests
-        run: tox -e integration
-      - name: Archive Tested Charm
-        uses: actions/upload-artifact@v4
-        if: ${{ github.ref_name == 'main' }}
-        with:
-          name: tested-charm
-          path: .tox/**/${{ inputs.charm-file-name }}
-          retention-days: 5
-      - name: Archive charmcraft logs
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: charmcraft-logs
-          path: /home/runner/.local/state/charmcraft/log/*.log
-      - name: Archive juju crashdump
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: juju-crashdump
-          path: juju-crashdump-*.tar.xz
+        run: |
+          tox -e integration -- \
+            --charm_path="${{ steps.charm-path.outputs.charm_path }}" \
+            --kv_requirer_charm_path="${{ steps.kv-requirer-charm-path.outputs.charm_path }}"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -33,7 +33,11 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           juju-channel: 3.4/stable
-          provider: lxd
+          provider: microk8s
+          channel: 1.29-strict/stable
+          lxd-channel: 5.20/stable
+      - name: Enable Metallb
+        run: /usr/bin/sg snap_microk8s -c "sudo microk8s enable metallb:10.0.0.2-10.0.0.10"
 
       - name: Install tox
         run: pip install tox
@@ -43,3 +47,17 @@ jobs:
           tox -e integration -- \
             --charm_path="${{ steps.charm-path.outputs.charm_path }}" \
             --kv_requirer_charm_path="${{ steps.kv-requirer-charm-path.outputs.charm_path }}"
+
+      - name: Archive charmcraft logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: charmcraft-logs
+          path: /home/runner/.local/state/charmcraft/log/*.log
+
+      - name: Archive juju crashdump
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: juju-crashdump
+          path: juju-crashdump-*.tar.xz

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -23,13 +23,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
           channel: 1.29-strict/stable
           juju-channel: 3.4/stable
+          lxd-channel: 5.20/stable
       - name: Enable Metallb
         if: ${{ inputs.enable-metallb == true }}
         run: /usr/bin/sg snap_microk8s -c "sudo microk8s enable metallb:${{ inputs.metallb-range }}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,12 +25,20 @@ jobs:
 
   unit-tests-with-coverage:
     uses: ./.github/workflows/unit-test.yaml
+  
+  build:
+    needs:
+      - lint-report
+      - static-analysis
+      - unit-tests-with-coverage
+    uses: ./.github/workflows/build.yaml
+    secrets: inherit
 
   integration-test:
+    needs:
+      - build
     uses: ./.github/workflows/integration-test.yaml
-    with:
-      charm-file-name: "vault-k8s_ubuntu-22.04-amd64.charm"
-      enable-metallb: true
+    secrets: inherit
 
   publish-charm:
     needs:
@@ -41,7 +49,4 @@ jobs:
       - integration-test
     if: ${{ github.ref_name == 'main' }}
     uses: ./.github/workflows/publish-charm.yaml
-    with:
-      charm-file-name: "vault-k8s_ubuntu-22.04-amd64.charm"
     secrets: inherit
-

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -2,11 +2,6 @@ name: Publish charm
 
 on:
   workflow_call:
-    inputs:
-      charm-file-name:
-        description: Charm file name
-        required: true
-        type: string
     secrets:
       CHARMCRAFT_AUTH:
         required: true
@@ -16,29 +11,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-        with:
-          fetch-depth: 0
-      - name: Install charmcraft
-        run: sudo snap install charmcraft --classic
+        uses: actions/checkout@v4
+
       - name: Fetch Tested Charm
         uses: actions/download-artifact@v4
         with:
-          name: tested-charm
-      - name: Move charm in current directory
-        run: find ./ -name ${{ inputs.charm-file-name }} -exec mv -t ./ {} \;
+          name: built-charm
+      
+      - name: Get Charm Under Test Path
+        id: charm-path
+        run: echo "charm_path=$(find . -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.4.0
         with:
-          built-charm-path: ${{ inputs.charm-file-name }}
+          built-charm-path: ${{ steps.charm-path.outputs.charm_path }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: 1.15/edge
-      - name: Publish libs
-        uses: canonical/charming-actions/release-libraries@2.4.0
-        with:
-          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import os
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Add options to the pytest command line.
+
+    This is a pytest hook that is called when the pytest command line is being parsed.
+
+    Args:
+      parser: The pytest command line parser.
+    """
+    parser.addoption("--charm_path", action="store", default=None, help="Path to the charm under test")
+    parser.addoption("--kv_requirer_charm_path", action="store", default=None, help="Path to the KV requirer charm")
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Validate the options provided by the user.
+
+    This is a pytest hook that is called after command line options have been parsed.
+
+    Args:
+      config: The pytest configuration object.
+    """
+    charm_path = str(config.getoption("--charm_path"))
+    kv_requirer_charm_path = str(config.getoption("--kv_requirer_charm_path"))
+    if not charm_path:
+        pytest.exit("The --charm_path option is required. Tests aborted.")
+    if not kv_requirer_charm_path:
+        pytest.exit("The --kv_requirer_charm_path option is required. Tests aborted.")
+    if not os.path.exists(charm_path):
+        pytest.exit(f"The path specified does not exist: {charm_path}")
+    if not os.path.exists(kv_requirer_charm_path):
+        pytest.exit(f"The path specified does not exist: {kv_requirer_charm_path}")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,15 +1,8 @@
 #!/usr/bin/env python3
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
+
 from juju.unit import Unit
-from lightkube.core.client import Client as KubernetesClient
-from lightkube.resources.core_v1 import Pod
-
-
-def crash_pod(name: str, namespace: str) -> None:
-    """Simulate a pod crash by deleting the pod."""
-    k8s = KubernetesClient()  # type: ignore until https://github.com/gtsystem/lightkube/pull/60 is merged
-    k8s.delete(Pod, name=name, namespace=namespace)
 
 
 async def get_leader_unit(model, application_name: str) -> Unit:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -3,7 +3,14 @@
 # See LICENSE file for licensing details.
 
 from juju.unit import Unit
+from lightkube.core.client import Client as KubernetesClient
+from lightkube.resources.core_v1 import Pod
 
+
+def crash_pod(name: str, namespace: str) -> None:
+    """Simulate a pod crash by deleting the pod."""
+    k8s = KubernetesClient()  # type: ignore until https://github.com/gtsystem/lightkube/pull/60 is merged
+    k8s.delete(Pod, name=name, namespace=namespace)
 
 async def get_leader_unit(model, application_name: str) -> Unit:
     """Return the leader unit for the given application."""

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-
 from juju.unit import Unit
 from lightkube.core.client import Client as KubernetesClient
 from lightkube.resources.core_v1 import Pod
@@ -11,6 +10,7 @@ def crash_pod(name: str, namespace: str) -> None:
     """Simulate a pod crash by deleting the pod."""
     k8s = KubernetesClient()  # type: ignore until https://github.com/gtsystem/lightkube/pull/60 is merged
     k8s.delete(Pod, name=name, namespace=namespace)
+
 
 async def get_leader_unit(model, application_name: str) -> Unit:
     """Return the leader unit for the given application."""

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -264,7 +264,11 @@ class TestVaultK8sIntegrationsPart1:
             deploy_vault_kv_requirer,
         )
         await ops_test.model.wait_for_idle(
-            apps=deployed_apps,
+            apps=[
+                SELF_SIGNED_CERTIFICATES_APPLICATION_NAME,
+                VAULT_KV_REQUIRER_APPLICATION_NAME,
+                VAULT_PKI_REQUIRER_APPLICATION_NAME,
+            ],
             status="active",
             timeout=1000,
             wait_for_exact_units=1,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -374,11 +374,6 @@ class TestVaultK8sIntegrationsPart1:
             relation1=f"{SELF_SIGNED_CERTIFICATES_APPLICATION_NAME}:certificates",
             relation2=f"{TRAEFIK_APPLICATION_NAME}",
         )
-        await ops_test.model.wait_for_idle(
-            apps=[TRAEFIK_APPLICATION_NAME],
-            status="active",
-            timeout=1000,
-        )
 
     @pytest.mark.abort_on_fail
     async def test_given_traefik_is_deployed_when_certificate_transfer_interface_is_related_then_status_is_active(
@@ -390,7 +385,7 @@ class TestVaultK8sIntegrationsPart1:
             relation2=f"{TRAEFIK_APPLICATION_NAME}:receive-ca-cert",
         )
         await ops_test.model.wait_for_idle(
-            apps=[APPLICATION_NAME, TRAEFIK_APPLICATION_NAME],
+            apps=[APPLICATION_NAME],
             status="active",
             timeout=1000,
         )
@@ -405,7 +400,7 @@ class TestVaultK8sIntegrationsPart1:
             relation2=f"{TRAEFIK_APPLICATION_NAME}:ingress",
         )
         await ops_test.model.wait_for_idle(
-            apps=[APPLICATION_NAME, TRAEFIK_APPLICATION_NAME],
+            apps=[APPLICATION_NAME],
             status="active",
             timeout=1000,
         )


### PR DESCRIPTION
# Description

Standardise integration tests with the machine charm. This includes:
- Build charm in separate workflow step
- Remove dependency on Traefik
- Freeze LXD to `5.20/stable`

## TO DO

- Re-add backup/restore with s3
- Re-add scale up/down tests

## Rationale

Integration tests are consistently failing because of two reasons:
1. Traefik gets into an error state. Our integration tests should not fail because of this. Here we do not care anymore that traefik is not in active/idle.
2. LXD silently updated to `5.21/stable` which is not compatible with charmcraft. Here we freeze it to `5.20/stable`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
