### PR TITLE
chore: build charm in independent workflow step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,54 @@
+name: Build
+
+on:
+  workflow_call:
+
+jobs:
+  build-charm-under-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+    
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+        with:
+            channel: 5.20/stable
+    
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Build charm under test
+        run: charmcraft pack --verbose
+
+      - name: Archive Charm Under Test
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-charm
+          path: "*.charm"
+          retention-days: 5
+
+  build-kv-requirer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+        with:
+          channel: 5.20/stable
+      
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Build KV Requirer charm
+        run: |
+          cp lib/charms/vault_k8s/v0/vault_kv.py tests/integration/vault_kv_requirer_operator/lib/charms/vault_k8s/v0/vault_kv.py
+          cd tests/integration/vault_kv_requirer_operator
+          charmcraft pack --verbose
+
+      - name: Archive KV Requirer Charm
+        uses: actions/upload-artifact@v4
+        with:
+          name: kv-requirer-charm
+          path: tests/integration/vault_kv_requirer_operator/*.charm
+          retention-days: 5

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -42,9 +42,10 @@ jobs:
         run: /usr/bin/sg snap_microk8s -c "sudo microk8s enable metallb:10.0.0.2-10.0.0.10"
 
       - name: Run integration tests
-        run: tox -e integration -- \
-          --charm_path="${{ steps.charm-path.outputs.charm_path }}" \
-          --kv_requirer_charm_path="${{ steps.kv-requirer-charm-path.outputs.charm_path }}"
+        run: |
+          tox -e integration -- \
+            --charm_path="${{ steps.charm-path.outputs.charm_path }}" \
+            --kv_requirer_charm_path="${{ steps.kv-requirer-charm-path.outputs.charm_path }}"
   
       - name: Archive charmcraft logs
         if: failure()

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -2,28 +2,34 @@ name: Integration tests
 
 on:
   workflow_call:
-    inputs:
-      charm-file-name:
-        description: Tested charm file name
-        required: true
-        type: string
-      enable-metallb:
-        description: Enable MetalLB
-        required: false
-        type: boolean
-        default: false
-      metallb-range:
-        description: MetalLB range
-        required: false
-        type: string
-        default: "10.0.0.2-10.0.0.10"
 
 jobs:
   integration-test:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
+      
+      - name: Fetch Charm Under Test
+        uses: actions/download-artifact@v4
+        with:
+          name: built-charm
+          path: built/
+      
+      - name: Get Charm Under Test Path
+        id: charm-path
+        run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+      
+      - name: Fetch KV Requirer Charm
+        uses: actions/download-artifact@v4
+        with:
+          name: kv-requirer-charm
+          path: kv-requirer/
+      
+      - name: Get KV Requirer Charm Path
+        id: kv-requirer-charm-path
+        run: echo "charm_path=$(find kv-requirer/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -31,24 +37,22 @@ jobs:
           channel: 1.29-strict/stable
           juju-channel: 3.4/stable
           lxd-channel: 5.20/stable
+  
       - name: Enable Metallb
-        if: ${{ inputs.enable-metallb == true }}
-        run: /usr/bin/sg snap_microk8s -c "sudo microk8s enable metallb:${{ inputs.metallb-range }}"
+        run: /usr/bin/sg snap_microk8s -c "sudo microk8s enable metallb:10.0.0.2-10.0.0.10"
+
       - name: Run integration tests
-        run: tox -e integration
-      - name: Archive Tested Charm
-        uses: actions/upload-artifact@v4
-        if: ${{ github.ref_name == 'main' }}
-        with:
-          name: tested-charm
-          path: .tox/**/${{ inputs.charm-file-name }}
-          retention-days: 5
+        run: tox -e integration -- \
+          --charm_path="${{ steps.charm-path.outputs.charm_path }}" \
+          --kv_requirer_charm_path="${{ steps.kv-requirer-charm-path.outputs.charm_path }}"
+  
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: charmcraft-logs
           path: /home/runner/.local/state/charmcraft/log/*.log
+  
       - name: Archive juju crashdump
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,12 +25,19 @@ jobs:
 
   unit-tests-with-coverage:
     uses: ./.github/workflows/unit-test.yaml
+  
+  build:
+    needs:
+      - lint-report
+      - static-analysis
+      - unit-tests-with-coverage
+    uses: ./.github/workflows/build.yaml
+    secrets: inherit
 
   integration-test:
+    needs: 
+      - build
     uses: ./.github/workflows/integration-test.yaml
-    with:
-      charm-file-name: "vault-k8s_ubuntu-22.04-amd64.charm"
-      enable-metallb: true
 
   publish-charm:
     needs:
@@ -41,7 +48,4 @@ jobs:
       - integration-test
     if: ${{ github.ref_name == 'main' }}
     uses: ./.github/workflows/publish-charm.yaml
-    with:
-      charm-file-name: "vault-k8s_ubuntu-22.04-amd64.charm"
     secrets: inherit
-

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -2,11 +2,6 @@ name: Publish charm
 
 on:
   workflow_call:
-    inputs:
-      charm-file-name:
-        description: Charm file name
-        required: true
-        type: string
     secrets:
       CHARMCRAFT_AUTH:
         required: true
@@ -16,29 +11,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
+
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
+
       - name: Fetch Tested Charm
         uses: actions/download-artifact@v4
         with:
-          name: tested-charm
-      - name: Move charm in current directory
-        run: find ./ -name ${{ inputs.charm-file-name }} -exec mv -t ./ {} \;
+          name: built-charm
+      
+      - name: Get Charm Under Test Path
+        id: charm-path
+        run: echo "charm_path=$(find . -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
+  
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.4.0
         with:
-          built-charm-path: ${{ inputs.charm-file-name }}
+          built-charm-path: ${{ steps.charm-path.outputs.charm_path }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: 1.15/edge
+  
       - name: Publish libs
         uses: canonical/charming-actions/release-libraries@2.4.0
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+  
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import os
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Add options to the pytest command line.
+
+    This is a pytest hook that is called when the pytest command line is being parsed.
+
+    Args:
+      parser: The pytest command line parser.
+    """
+    parser.addoption("--charm_path", action="store", default=None, help="Path to the charm under test")
+    parser.addoption("--kv_requirer_charm_path", action="store", default=None, help="Path to the KV requirer charm")
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Validate the options provided by the user.
+
+    This is a pytest hook that is called after command line options have been parsed.
+
+    Args:
+      config: The pytest configuration object.
+    """
+    charm_path = str(config.getoption("--charm_path"))
+    kv_requirer_charm_path = str(config.getoption("--kv_requirer_charm_path"))
+    if not charm_path:
+        pytest.exit("The --charm_path option is required. Tests aborted.")
+    if not kv_requirer_charm_path:
+        pytest.exit("The --kv_requirer_charm_path option is required. Tests aborted.")
+    if not os.path.exists(charm_path):
+        pytest.exit(f"The path specified does not exist: {charm_path}")
+    if not os.path.exists(kv_requirer_charm_path):
+        pytest.exit(f"The path specified does not exist: {kv_requirer_charm_path}")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -33,6 +33,6 @@ def pytest_configure(config: pytest.Config) -> None:
     if not kv_requirer_charm_path:
         pytest.exit("The --kv_requirer_charm_path option is required. Tests aborted.")
     if not os.path.exists(charm_path):
-        pytest.exit(f"The path specified does not exist: {charm_path}")
+        pytest.exit(f"The path specified for the charm under test does not exist: {charm_path}")
     if not os.path.exists(kv_requirer_charm_path):
-        pytest.exit(f"The path specified does not exist: {kv_requirer_charm_path}")
+        pytest.exit(f"The path specified for KV Requirer does not exist: {kv_requirer_charm_path}")


### PR DESCRIPTION
# Description

We move the charm build process to its own workflow stage. We build the charm, we test it, and we publish it, all with the same artifact. This brings the k8s charm in line with the machine charm approach. 

![image](https://github.com/canonical/vault-operator/assets/18486508/96adce3b-56a9-4f21-9414-916ba749354b)

## Usage

```
tox -e integration -- \
  --charm_path=<vault charm path> \
  --kv_requirer_charm_path=<KV requirer charm path>
```

## Rationale

1. This reduces the amount of resources taken by the integration tests which is the step that takes the largest amount of GH runners resources.
2. Each step has its own precise role instead of having the built artifact be a side effect of running the integration tests. In other words, we won't be noticed of a build failure through an integration test failure anymore. 
    - In cases where the CI fails because the charm doesn't build, it's quicker to identify that this isse is build related.
    - Build won't run if the unit, static or lint fails
    - Integration tests won't run if the build fails

## Notes
- While this change reduces the resources taken by the integration tests, it increases the total resource usage. With more workflow steps requires downloading the same dependencies multiple times. This also increases the total CI time. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
