### PR TITLE
fix: check if relation is active before syncing kv

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/lib/charms/vault_k8s/v0/vault_kv.py
@@ -135,7 +135,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 
@@ -327,7 +327,12 @@ class VaultKvProvides(ops.Object):
         """Set the ca_certificate on the relation."""
         if not self.charm.unit.is_leader():
             return
-
+        if not relation:
+            logger.warning("Relation is None")
+            return
+        if not relation.active:
+            logger.warning("Relation is not active")
+            return
         relation.data[self.charm.app]["ca_certificate"] = ca_certificate
 
     def set_mount(self, relation: ops.Relation, mount: str):
@@ -398,6 +403,8 @@ class VaultKvProvides(ops.Object):
         )
         for relation in relations:
             assert isinstance(relation.app, ops.Application)
+            if not relation.active:
+                continue
             app_data = relation.data[relation.app]
             for unit in relation.units:
                 unit_data = relation.data[unit]

--- a/src/charm.py
+++ b/src/charm.py
@@ -250,10 +250,6 @@ class VaultCharm(CharmBase):
         if not self.unit.is_leader() and not self.tls.tls_file_pushed_to_workload(File.CA):
             return
 
-        for relation in self.model.relations[KV_RELATION_NAME]:
-            ca_certificate = self.tls.pull_tls_file_from_workload(File.CA)
-            self.vault_kv.set_ca_certificate(relation, ca_certificate)
-
         self._generate_vault_config_file()
         self._set_pebble_plan()
         vault = Vault(
@@ -318,6 +314,9 @@ class VaultCharm(CharmBase):
         )
         if not relation:
             logger.error("Relation not found for relation id %s", event.relation_id)
+            return
+        if not relation.active:
+            logger.error("Relation is not active for relation id %s", event.relation_id)
             return
         self._generate_kv_for_requirer(
             relation=relation,
@@ -415,6 +414,9 @@ class VaultCharm(CharmBase):
             )
             if not relation:
                 logger.warning("Relation not found for relation id %s", kv_request.relation_id)
+                continue
+            if not relation.active:
+                logger.warning("Relation is not active for relation id %s", kv_request.relation_id)
                 continue
             self._generate_kv_for_requirer(
                 relation=relation,


### PR DESCRIPTION
# Description

We now check if the relation is active before syncing kv values in all relations. Broken relations still count as relations in the relation-broken event and we must make sure that we don't insert data in there.

Fixes #241 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
