### PR TITLE
fix: Catch connection errors when logging in to vault

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -26,7 +26,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 
 logger = logging.getLogger(__name__)

--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -16,7 +16,7 @@ from typing import Dict, List, Optional, Protocol
 import hvac
 import requests
 from hvac.exceptions import Forbidden, InvalidPath, InvalidRequest, VaultError
-from requests.exceptions import RequestException
+from requests.exceptions import ConnectionError, RequestException
 
 # The unique Charmhub library identifier, never change it
 LIBID = "674754a3268d4507b749ec34214706fd"
@@ -109,7 +109,7 @@ class Vault:
         """Find and use the token related with the given auth method."""
         try:
             auth_details.login(self._client)
-        except (VaultError, ConnectionRefusedError) as e:
+        except (VaultError, ConnectionError) as e:
             logger.error("Failed logging in to Vault: %s", e)
             return False
         return True


### PR DESCRIPTION
# Description

From #303: 

"looks like this crash is happening in collect-status right after the tls integration is gone. My initial impression is that when tls-certificates-access-relation-changed fires, the workload is restarted, and collect status immediately tries to connect to a workload that's restarting. This doesn't explain how it may sometimes work. Maybe it's happening so close to the pebble call that an http request gets through before k8s/pebble could schedule a restart.

Connection Refused is being caught at the client level right now, but it seems like python is actually throwing a requests.exceptions.ConnectionError to the client code. This is the exception that should probably be caught in Vault.authenticate."

Fixes #303 

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
