### PR TITLE
fix: Check for CA file availability instead of storage itself

### DIFF
--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_tls.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_tls.py
@@ -131,7 +131,7 @@ class TestCharmTLS(unittest.TestCase):
 
         self.assertEqual(
             self.harness.charm.unit.status,
-            WaitingStatus("Waiting for CA certificate secret"),
+            WaitingStatus("Waiting for CA certificate to be accessible in the charm"),
         )
 
     @patch("charms.vault_k8s.v0.vault_client.Vault.enable_audit_device", new=Mock)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -360,7 +360,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.charm.unit.status,
-            WaitingStatus("Storage for certificates not mounted"),
+            WaitingStatus("Waiting for CA certificate to be accessible in the charm"),
         )
 
     @patch("charm.VaultCharm._ingress_address", new=PropertyMock(return_value="1.1.1.1"))
@@ -386,7 +386,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.charm.unit.status,
-            WaitingStatus("Waiting for CA certificate secret"),
+            WaitingStatus("Waiting for CA certificate to be accessible in the charm"),
         )
 
     @patch("charm.VaultCharm._ingress_address", new=PropertyMock(return_value="1.1.1.1"))
@@ -412,7 +412,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.charm.unit.status,
-            WaitingStatus("Waiting for CA certificate to be shared"),
+            WaitingStatus("Waiting for CA certificate to be accessible in the charm"),
         )
 
     @patch("charm.Vault", autospec=True)
@@ -503,6 +503,8 @@ class TestCharm(unittest.TestCase):
 
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
+        root = self.harness.get_filesystem_root(self.container_name)
+        (root / "vault/certs/ca.pem").write_text("some ca")
         self.harness.set_can_connect(container=self.container_name, val=True)
         self.harness.set_leader(is_leader=True)
         self._set_peer_relation()


### PR DESCRIPTION
# Description

Fixes #311. Checks if the CA file exists in Vault instead of just checking if the storage path is available for collect status.
 
# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
