### PR TITLE
fix: use latest version of juju secret

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_tls.py
+++ b/lib/charms/vault_k8s/v0/vault_tls.py
@@ -34,7 +34,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 
 logger = logging.getLogger(__name__)
@@ -344,7 +344,7 @@ class VaultTLSManager(Object):
             Tuple[Optional[str], Optional[str]]: The CA private key and certificate
         """
         juju_secret = self.charm.model.get_secret(label=CA_CERTIFICATE_JUJU_SECRET_LABEL)
-        content = juju_secret.get_content()
+        content = juju_secret.get_content(refresh=True)
         return content["privatekey"], content["certificate"]
 
     def _set_ca_certificate_secret(

--- a/src/charm.py
+++ b/src/charm.py
@@ -869,7 +869,7 @@ class VaultCharm(CharmBase):
         """Update a vault kv secret if the unit subnet is not in the cidr list."""
         secret = self.model.get_secret(id=secret_id, label=label)
         secret.grant(relation)
-        credentials = secret.get_content()
+        credentials = secret.get_content(refresh=True)
         role_secret_id_data = vault.read_role_secret(role_name, credentials["role-secret-id"])
         # if unit subnet is already in cidr_list, skip
         if egress_subnet in role_secret_id_data["cidr_list"]:
@@ -1006,7 +1006,7 @@ class VaultCharm(CharmBase):
         if not self._pki_csr_secret_set():
             raise RuntimeError("PKI CSR secret not set.")
         secret = self.model.get_secret(label=PKI_CSR_SECRET_LABEL)
-        return secret.get_content()["csr"]
+        return secret.get_content(refresh=True)["csr"]
 
     def _pki_csr_secret_set(self) -> bool:
         """Return whether PKI CSR secret is stored."""
@@ -1024,7 +1024,7 @@ class VaultCharm(CharmBase):
         """
         try:
             juju_secret = self.model.get_secret(label=VAULT_CHARM_APPROLE_SECRET_LABEL)
-            content = juju_secret.get_content()
+            content = juju_secret.get_content(refresh=True)
         except SecretNotFoundError:
             return None, None
         return content["role-id"], content["secret-id"]

--- a/tests/integration/vault_kv_requirer_operator/src/charm.py
+++ b/tests/integration/vault_kv_requirer_operator/src/charm.py
@@ -72,7 +72,7 @@ class VaultKVRequirerCharm(CharmBase):
             return
         unit_credentials = self.vault_kv.get_unit_credentials(relation)
         secret = self.model.get_secret(id=unit_credentials)
-        secret_content = secret.get_content()
+        secret_content = secret.get_content(refresh=True)
         juju_secret_content = {
             "vault-url": vault_url,
             "mount": mount,
@@ -101,7 +101,7 @@ class VaultKVRequirerCharm(CharmBase):
         except SecretNotFoundError:
             event.fail("Vault KV secret not found")
             return
-        secret_content = secret.get_content()
+        secret_content = secret.get_content(refresh=True)
         mount = secret_content["mount"]
         ca_certificate_path = self._get_ca_cert_location_in_charm()
         if ca_certificate_path is None:
@@ -128,7 +128,7 @@ class VaultKVRequirerCharm(CharmBase):
         except SecretNotFoundError:
             event.fail("Vault KV secret not found")
             return
-        secret_content = secret.get_content()
+        secret_content = secret.get_content(refresh=True)
         mount = secret_content["mount"]
         ca_certificate_path = self._get_ca_cert_location_in_charm()
         if ca_certificate_path is None:
@@ -153,7 +153,7 @@ class VaultKVRequirerCharm(CharmBase):
     def get_nonce(self) -> str:
         """Get the nonce from the secret."""
         secret = self.model.get_secret(label=NONCE_SECRET_LABEL)
-        return secret.get_content()["nonce"]
+        return secret.get_content(refresh=True)["nonce"]
 
     def _get_ca_cert_location_in_charm(self) -> Optional[Path]:
         """Return the CA certificate location in the charm (not in the workload).


### PR DESCRIPTION
# Description

We refresh the juju secret when checking its content making sure we are reading its latest value instead of an older one. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
