### PR TITLE
fix: Moves boto3 related dependencies to requirements.in

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,4 +12,3 @@ requests
 jsonschema
 cryptography
 boto3
-boto3-stubs[s3]

--- a/requirements.in
+++ b/requirements.in
@@ -12,3 +12,4 @@ requests
 jsonschema
 cryptography
 boto3
+boto3-stubs[s3] # required by vault_s3

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,6 @@ botocore==1.34.89
     # via
     #   boto3
     #   s3transfer
-botocore-stubs==1.34.85
-    # via boto3-stubs
 certifi==2024.2.2
     # via
     #   httpcore
@@ -70,8 +68,6 @@ lightkube-models==1.30.0.7
     #   lightkube
 markupsafe==2.1.5
     # via jinja2
-mypy-boto3-s3==1.34.65
-    # via boto3-stubs
 ops==2.12.0
     # via
     #   -r requirements.in
@@ -81,7 +77,7 @@ ops-scenario==6.0.3
     # via pytest-interface-tester
 packaging==24.0
     # via pytest
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 pycparser==2.22
     # via cffi
@@ -127,15 +123,9 @@ sniffio==1.3.1
     #   httpx
 typer==0.7.0
     # via pytest-interface-tester
-types-awscrt==0.20.9
-    # via botocore-stubs
-types-s3transfer==0.10.1
-    # via boto3-stubs
 typing-extensions==4.11.0
     # via
-    #   boto3-stubs
     #   cosl
-    #   mypy-boto3-s3
     #   pydantic
     #   pydantic-core
 urllib3==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,12 +14,14 @@ attrs==23.2.0
     #   referencing
 boto3==1.34.89
     # via -r requirements.in
-boto3-stubs[s3]==1.34.85
+boto3-stubs[s3]==1.34.89
     # via -r requirements.in
 botocore==1.34.89
     # via
     #   boto3
     #   s3transfer
+botocore-stubs==1.34.89
+    # via boto3-stubs
 certifi==2024.2.2
     # via
     #   httpcore
@@ -68,6 +70,8 @@ lightkube-models==1.30.0.7
     #   lightkube
 markupsafe==2.1.5
     # via jinja2
+mypy-boto3-s3==1.34.65
+    # via boto3-stubs
 ops==2.12.0
     # via
     #   -r requirements.in
@@ -123,9 +127,15 @@ sniffio==1.3.1
     #   httpx
 typer==0.7.0
     # via pytest-interface-tester
+types-awscrt==0.20.9
+    # via botocore-stubs
+types-s3transfer==0.10.1
+    # via boto3-stubs
 typing-extensions==4.11.0
     # via
+    #   boto3-stubs
     #   cosl
+    #   mypy-boto3-s3
     #   pydantic
     #   pydantic-core
 urllib3==2.2.1

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -5,6 +5,4 @@ pyright
 pytest
 pytest-operator
 ruff
-types-boto3
-boto3-stubs[s3]
 types-hvac

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -6,4 +6,5 @@ pytest
 pytest-operator
 ruff
 types-boto3
+boto3-stubs[s3]
 types-hvac

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,28 +8,36 @@ asttokens==2.4.1
     # via stack-data
 bcrypt==4.1.2
     # via paramiko
-boto3-stubs==1.34.85
-    # via types-boto3
-botocore-stubs==1.34.85
+boto3-stubs[s3]==1.34.88
+    # via
+    #   -r test-requirements.in
+    #   types-boto3
+botocore-stubs==1.34.88
     # via boto3-stubs
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 codespell==2.2.6
     # via -r test-requirements.in
 coverage[toml]==7.4.4
     # via -r test-requirements.in
 cryptography==42.0.5
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
@@ -39,11 +47,17 @@ executing==2.0.1
 google-auth==2.29.0
     # via kubernetes
 hvac==2.1.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 idna==3.7
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
 ipython==8.23.0
@@ -51,7 +65,9 @@ ipython==8.23.0
 jedi==0.19.1
     # via ipython
 jinja2==3.1.3
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.4.0.0
     # via
     #   -r test-requirements.in
@@ -61,9 +77,13 @@ kubernetes==29.0.0
 macaroonbakery==1.3.4
     # via juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.7
     # via ipython
+mypy-boto3-s3==1.34.65
+    # via boto3-stubs
 mypy-extensions==1.0.0
     # via typing-inspect
 nodeenv==1.8.0
@@ -74,6 +94,7 @@ oauthlib==3.2.2
     #   requests-oauthlib
 packaging==24.0
     # via
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.4.0
@@ -82,8 +103,10 @@ parso==0.8.4
     # via jedi
 pexpect==4.9.0
     # via ipython
-pluggy==1.4.0
-    # via pytest
+pluggy==1.5.0
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.43
     # via ipython
 protobuf==5.26.1
@@ -100,7 +123,9 @@ pyasn1==0.6.0
 pyasn1-modules==0.4.0
     # via google-auth
 pycparser==2.22
-    # via cffi
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0
@@ -118,6 +143,7 @@ pyright==1.1.359
     # via -r test-requirements.in
 pytest==8.1.1
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -126,16 +152,20 @@ pytest-asyncio==0.21.1
 pytest-operator==0.34.0
     # via -r test-requirements.in
 python-dateutil==2.9.0.post0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 pytz==2024.1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   pytest-operator
 requests==2.31.0
     # via
+    #   -c requirements.txt
     #   hvac
     #   kubernetes
     #   macaroonbakery
@@ -148,6 +178,7 @@ ruff==0.4.1
     # via -r test-requirements.in
 six==1.16.0
     # via
+    #   -c requirements.txt
     #   asttokens
     #   kubernetes
     #   macaroonbakery
@@ -157,7 +188,7 @@ stack-data==0.6.3
     # via ipython
 toposort==1.10
     # via juju
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
@@ -173,20 +204,25 @@ types-s3transfer==0.10.1
     # via boto3-stubs
 typing-extensions==4.11.0
     # via
+    #   -c requirements.txt
     #   boto3-stubs
     #   ipython
+    #   mypy-boto3-s3
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
 urllib3==2.2.1
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
     #   types-requests
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 websockets==12.0
     # via juju
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,12 +8,6 @@ asttokens==2.4.1
     # via stack-data
 bcrypt==4.1.2
     # via paramiko
-boto3-stubs[s3]==1.34.88
-    # via
-    #   -r test-requirements.in
-    #   types-boto3
-botocore-stubs==1.34.88
-    # via boto3-stubs
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
@@ -82,8 +76,6 @@ markupsafe==2.1.5
     #   jinja2
 matplotlib-inline==0.1.7
     # via ipython
-mypy-boto3-s3==1.34.65
-    # via boto3-stubs
 mypy-extensions==1.0.0
     # via typing-inspect
 nodeenv==1.8.0
@@ -192,22 +184,14 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-types-awscrt==0.20.9
-    # via botocore-stubs
-types-boto3==1.0.2
-    # via -r test-requirements.in
 types-hvac==2.1.0.20240329
     # via -r test-requirements.in
 types-requests==2.31.0.20240406
     # via types-hvac
-types-s3transfer==0.10.1
-    # via boto3-stubs
 typing-extensions==4.11.0
     # via
     #   -c requirements.txt
-    #   boto3-stubs
     #   ipython
-    #   mypy-boto3-s3
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju


### PR DESCRIPTION
# Description

Moves boto3 related dependencies to requirements.in
boto3-stubs is a transitive dependency of types-boto3 that is used in the test-requirements, therefore to avoid any conflicts we keep all boto3 related dependencies in one place.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
