### PR TITLE
fix: Improves docstring to instruct the requirer to refresh the credentials secret when fetching it.

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/lib/charms/vault_k8s/v0/vault_kv.py
@@ -68,7 +68,7 @@ class ExampleRequirerCharm(CharmBase):
         unit_credentials = self.interface.get_unit_credentials(relation)
         # unit_credentials is a juju secret id
         secret = self.model.get_secret(id=unit_credentials)
-        secret_content = secret.get_content()
+        secret_content = secret.get_content(refresh=True)
         role_id = secret_content["role-id"]
         role_secret_id = secret_content["role-secret-id"]
 
@@ -99,7 +99,7 @@ class ExampleRequirerCharm(CharmBase):
 
     def get_nonce(self):
         secret = self.model.get_secret(label=NONCE_SECRET_LABEL)
-        nonce = secret.get_content()["nonce"]
+        nonce = secret.get_content(refresh=True)["nonce"]
         return nonce
 
 

--- a/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/lib/charms/vault_k8s/v0/vault_kv.py
@@ -132,7 +132,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 


### PR DESCRIPTION
# Description

When the Vault KV library updates the login credentials the requirer must use the refresh parameter when fetching the credentials secret to get the updated ones.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
