### PR TITLE
fix: Sets the latest issuer to be the default issuer in PKI

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -26,7 +26,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 
 RAFT_STATE_ENDPOINT = "v1/sys/storage/raft/autopilot/state"

--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -423,8 +423,8 @@ class Vault:
             first_issuer = self._client.secrets.pki.list_issuers(
                 mount_point=mount
             )["data"]["keys"][0]
-        except (InvalidPath, KeyError):
-            logger.error("No issuers found on the specified path.")
+        except (InvalidPath, KeyError) as e:
+            logger.error("No issuers found on the specified path: %s", e)
             raise VaultClientError("No issuers found on the specified path.")
         self._client.write_data(
             path=f"{mount}/config/issuers",

--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -416,3 +416,14 @@ class Vault:
         except InvalidPath:
             logger.error("Role does not exist on the specified path.")
             return False
+
+    def make_latest_pki_issuer_default(self, mount: str) -> None:
+        """Update the issuers config to always make the latest issuer created default issuer."""
+        first_issuer = self._client.secrets.pki.list_issuers(
+            mount_point="charm-pki"
+        )["data"]["keys"][0]
+        self._client.write(
+            f"{mount}/config/issuers",
+            default_follows_latest_issuer=True,
+            default=first_issuer,
+        )

--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -420,10 +420,12 @@ class Vault:
     def make_latest_pki_issuer_default(self, mount: str) -> None:
         """Update the issuers config to always make the latest issuer created default issuer."""
         first_issuer = self._client.secrets.pki.list_issuers(
-            mount_point="charm-pki"
+            mount_point=mount
         )["data"]["keys"][0]
-        self._client.write(
-            f"{mount}/config/issuers",
-            default_follows_latest_issuer=True,
-            default=first_issuer,
+        self._client.write_data(
+            path=f"{mount}/config/issuers",
+            data={
+                "default_follows_latest_issuer": True,
+                "default": first_issuer,
+            },
         )

--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -419,9 +419,13 @@ class Vault:
 
     def make_latest_pki_issuer_default(self, mount: str) -> None:
         """Update the issuers config to always make the latest issuer created default issuer."""
-        first_issuer = self._client.secrets.pki.list_issuers(
-            mount_point=mount
-        )["data"]["keys"][0]
+        try:
+            first_issuer = self._client.secrets.pki.list_issuers(
+                mount_point=mount
+            )["data"]["keys"][0]
+        except (InvalidPath, KeyError):
+            logger.error("No issuers found on the specified path.")
+            raise VaultClientError("No issuers found on the specified path.")
         self._client.write_data(
             path=f"{mount}/config/issuers",
             data={

--- a/src/charm.py
+++ b/src/charm.py
@@ -398,6 +398,7 @@ class VaultCharm(CharmBase):
                 mount=PKI_MOUNT,
                 role=PKI_ROLE,
             )
+        vault.make_latest_pki_issuer_default(mount=PKI_MOUNT)
 
     def _sync_vault_pki(self) -> None:
         """Goes through all the vault-pki relations and sends necessary TLS certificate."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -399,7 +399,10 @@ class VaultCharm(CharmBase):
                 role=PKI_ROLE_NAME,
             )
         # Can run only after the first issuer has been actually created.
-        vault.make_latest_pki_issuer_default(mount=PKI_MOUNT)
+        try:
+            vault.make_latest_pki_issuer_default(mount=PKI_MOUNT)
+        except VaultClientError as e:
+            logger.error("Failed to make latest issuer default: %s", e)
 
     def _sync_vault_pki(self) -> None:
         """Goes through all the vault-pki relations and sends necessary TLS certificate."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -48,6 +48,9 @@ TLS_CERTIFICATES_LIB_PATH = "charms.tls_certificates_interface.v3.tls_certificat
 VAULT_KV_RELATION_NAME = "vault-kv"
 TLS_CERTIFICATES_PKI_RELATION_NAME = "tls-certificates-pki"
 VAULT_KV_REQUIRER_APPLICATION_NAME = "vault-kv-requirer"
+PKI_MOUNT = "charm-pki"
+PKI_ROLE_NAME = "charm"
+APPROLE_ROLE_NAME = "charm"
 
 
 def read_file(path: str) -> str:
@@ -536,10 +539,10 @@ class TestCharm(unittest.TestCase):
             policy_name=CHARM_POLICY_NAME, policy_path=CHARM_POLICY_PATH
         )
         self.mock_vault.configure_approle.assert_called_once_with(
-            role_name="charm", policies=[CHARM_POLICY_NAME, "default"], cidrs=["10.0.0.10/24"]
+            role_name=APPROLE_ROLE_NAME, policies=[CHARM_POLICY_NAME, "default"], cidrs=["10.0.0.10/24"]
         )
         self.mock_vault.generate_role_secret_id.assert_called_once_with(
-            name="charm", cidrs=["10.0.0.10/24"]
+            name=APPROLE_ROLE_NAME, cidrs=["10.0.0.10/24"]
         )
 
         secret_content = self.harness.model.get_secret(
@@ -1497,9 +1500,9 @@ class TestCharm(unittest.TestCase):
         )
         self.harness.add_relation_unit(relation_id, "tls-provider/0")
 
-        self.mock_vault.enable_secrets_engine.assert_called_with(SecretsBackend.PKI, "charm-pki")
+        self.mock_vault.enable_secrets_engine.assert_called_with(SecretsBackend.PKI, PKI_MOUNT)
         self.mock_vault.generate_pki_intermediate_ca_csr.assert_called_with(
-            mount="charm-pki", common_name="vault"
+            mount=PKI_MOUNT, common_name="vault"
         )
         patch_request_certificate_creation.assert_called_with(
             certificate_signing_request=csr.encode(), is_ca=True
@@ -1537,16 +1540,16 @@ class TestCharm(unittest.TestCase):
         )
         self.harness.add_relation_unit(relation_id, "tls-provider/0")
 
-        self.mock_vault.enable_secrets_engine.assert_called_with(SecretsBackend.PKI, "charm-pki")
+        self.mock_vault.enable_secrets_engine.assert_called_with(SecretsBackend.PKI, PKI_MOUNT)
         self.mock_vault.generate_pki_intermediate_ca_csr.assert_called_with(
-            mount="charm-pki", common_name="vault"
+            mount=PKI_MOUNT, common_name="vault"
         )
         patch_request_certificate_creation.assert_called_with(
             certificate_signing_request=csr.encode(), is_ca=True
         )
         self.harness.update_config({"common_name": "new_common_name"})
         self.mock_vault.generate_pki_intermediate_ca_csr.assert_called_with(
-            mount="charm-pki", common_name="new_common_name"
+            mount=PKI_MOUNT, common_name="new_common_name"
         )
         patch_request_certificate_creation.assert_called_with(
             certificate_signing_request=csr.encode(), is_ca=True
@@ -1609,10 +1612,10 @@ class TestCharm(unittest.TestCase):
 
         self.mock_vault.set_pki_intermediate_ca_certificate.assert_called_with(
             certificate=certificate,
-            mount="charm-pki",
+            mount=PKI_MOUNT,
         )
         self.mock_vault.create_or_update_pki_charm_role.assert_called_with(
-            allowed_domains="vault", mount="charm-pki", role="charm"
+            allowed_domains="vault", mount=PKI_MOUNT, role=PKI_ROLE_NAME
         )
 
     @patch("ops.model.Container.restart", new=Mock)
@@ -1674,10 +1677,10 @@ class TestCharm(unittest.TestCase):
 
         self.mock_vault.set_pki_intermediate_ca_certificate.assert_called_with(
             certificate=certificate,
-            mount="charm-pki",
+            mount=PKI_MOUNT,
         )
         self.mock_vault.create_or_update_pki_charm_role.assert_called_with(
-            allowed_domains="vault", mount="charm-pki", role="charm"
+            allowed_domains="vault", mount=PKI_MOUNT, role=PKI_ROLE_NAME
         )
 
         self.harness.update_config({"common_name": "new_common_name"})
@@ -1686,10 +1689,10 @@ class TestCharm(unittest.TestCase):
 
         self.mock_vault.set_pki_intermediate_ca_certificate.assert_called_with(
             certificate=certificate,
-            mount="charm-pki",
+            mount=PKI_MOUNT,
         )
         self.mock_vault.create_or_update_pki_charm_role.assert_called_with(
-            allowed_domains="new_common_name", mount="charm-pki", role="charm"
+            allowed_domains="new_common_name", mount=PKI_MOUNT, role=PKI_ROLE_NAME
         )
 
     @patch(f"{TLS_CERTIFICATES_LIB_PATH}.TLSCertificatesProvidesV3.set_relation_certificate")
@@ -1740,9 +1743,9 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_vault_pki_certificate_creation_request(event=event)
 
         self.mock_vault.sign_pki_certificate_signing_request.assert_called_with(
-            mount="charm-pki",
+            mount=PKI_MOUNT,
             csr=csr,
-            role="charm",
+            role=PKI_ROLE_NAME,
             common_name=common_name,
         )
 
@@ -1753,3 +1756,66 @@ class TestCharm(unittest.TestCase):
             ca=ca,
             chain=chain,
         )
+
+    @patch("charm.get_common_name_from_certificate", new=Mock)
+    @patch(f"{TLS_CERTIFICATES_LIB_PATH}.TLSCertificatesRequiresV3.get_assigned_certificates")
+    def test_given_vault_is_available_when_pki_certificate_is_available_then_default_issuer_is_set_to_latest_issuer(
+        self,
+        patch_get_assigned_certificates,
+    ):
+        self.mock_vault.configure_mock(
+            **{
+                "is_initialized.return_value": True,
+                "is_api_available.return_value": True,
+                "is_pki_role_created.return_value": False,
+                "get_intermediate_ca.return_value": "vault",
+                "is_common_name_allowed_in_pki_role.return_value": False,
+            },
+        )
+        csr = "some csr content"
+        certificate = "some certificate"
+        ca = "some ca"
+        chain = [ca]
+        self.harness.update_config({"common_name": "vault"})
+        self.harness.set_leader(is_leader=True)
+        self.harness.set_can_connect(container=self.container_name, val=True)
+        peer_relation_id = self._set_peer_relation()
+        self._set_approle_secret(
+            role_id="root token content",
+            secret_id="whatever secret id",
+        )
+        self._set_csr_secret_in_peer_relation(relation_id=peer_relation_id, csr="some csr content")
+        event = CertificateAvailableEvent(
+            handle=Mock(),
+            certificate=certificate,
+            certificate_signing_request=csr,
+            ca=ca,
+            chain=chain,
+        )
+        relation_id = self.harness.add_relation(
+            relation_name=TLS_CERTIFICATES_PKI_RELATION_NAME, remote_app="tls-provider"
+        )
+
+        patch_get_assigned_certificates.return_value = [
+            ProviderCertificate(
+                relation_id=relation_id,
+                application_name="tls-provider",
+                csr=csr,
+                certificate=certificate,
+                ca=ca,
+                chain=chain,
+                revoked=False,
+                expiry_time=datetime.now(timezone.utc),
+            )
+        ]
+
+        self.harness.charm._on_tls_certificate_pki_certificate_available(event=event)
+
+        self.mock_vault.set_pki_intermediate_ca_certificate.assert_called_with(
+            certificate=certificate,
+            mount=PKI_MOUNT,
+        )
+        self.mock_vault.create_or_update_pki_charm_role.assert_called_with(
+            allowed_domains="vault", mount=PKI_MOUNT, role=PKI_ROLE_NAME
+        )
+        self.mock_vault.make_latest_pki_issuer_default.assert_called_with(mount=PKI_MOUNT)


### PR DESCRIPTION
# Description

Since v1.11 Vault now creates a new issuer whenever a CA is added in PKI. However the default issuer is not updated by default, so when the charm checks the current intermediate CA it will get the one of the default (first) issuer, causing the charm to generate a new CSR and a new CA and push that to Vault over and over again once the common name is changed.

Although the charm would work as expected and provide certificates under the new common name, if the charm is deployed for long enough one would see a large number of CAs created.

This PR fixes that issue, now when a new common name is set and new CA is created we make sure that the new issuer is the default. This is achieved by setting the default issuer to the latest issuer after the creation of the first issuer.

**Note for reviewer**:
This is only a temporary fix to the phenomena described above, but the way to handle the change of CAs and Issuers should be agreed upon as part of the effort to define how to handle CA expiry and change in the TLS provider charms.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
