### PR TITLE
fix: Validate if issuers config was already updated before updating it

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -469,6 +469,14 @@ class Vault:
         except (InvalidPath, KeyError) as e:
             logger.error("No issuers found on the specified path: %s", e)
             raise VaultClientError("No issuers found on the specified path.")
+        try:
+            issuers_config = self._client.read(path=f"{mount}/config/issuers")
+            if issuers_config["data"]["default_follows_latest_issuer"] == True:
+                logger.debug("Config is already set")
+                return
+        except:
+            pass
+        logger.debug("Updating issuers config")
         self._client.write_data(
             path=f"{mount}/config/issuers",
             data={

--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -469,8 +469,8 @@ class Vault:
         except (InvalidPath, KeyError) as e:
             logger.error("No issuers found on the specified path: %s", e)
             raise VaultClientError("No issuers found on the specified path.")
-        issuers_config = self._client.read(path=f"{mount}/config/issuers")
         try:
+            issuers_config = self._client.read(path=f"{mount}/config/issuers")
             if issuers_config and not issuers_config["data"]["default_follows_latest_issuer"]:  # type: ignore -- bad type hint in stubs
                 logger.debug("Updating issuers config")
                 self._client.write_data(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -415,8 +415,7 @@ class TestVaultK8sIntegrationsPart1:
             "common_name": common_name,
         }
         await vault_app.set_config(common_name_config)
-        leader_unit_index, root_token, _ = initialize_leader_vault
-        unit_addresses = [row["address"] for row in await read_vault_unit_statuses(ops_test)]
+
         await ops_test.model.wait_for_idle(
             apps=[APPLICATION_NAME],
             status="active",
@@ -427,12 +426,15 @@ class TestVaultK8sIntegrationsPart1:
             apps=[VAULT_PKI_REQUIRER_APPLICATION_NAME],
             status="active",
             timeout=1000,
+            wait_for_exact_units=1,
         )
-        current_issuers_common_name = wait_for_vault_pki_issuer_config_update(
+
+        leader_unit_index, root_token, _ = initialize_leader_vault
+        unit_addresses = [row["address"] for row in await read_vault_unit_statuses(ops_test)]
+        current_issuers_common_name = get_vault_pki_intermediate_ca_common_name(
             root_token=root_token,
             endpoint=unit_addresses[leader_unit_index],
             mount="charm-pki",
-            expected_common_name=common_name,
         )
         action_output = await run_get_certificate_action(ops_test)
         assert current_issuers_common_name == common_name
@@ -965,16 +967,6 @@ async def authorize_charm(ops_test: OpsTest, root_token: str) -> Any | Dict:
         action_uuid=authorize_action.entity_id, wait=120
     )
     return result
-
-def wait_for_vault_pki_issuer_config_update(root_token: str, endpoint: str, mount: str, expected_common_name: str) -> str:
-    start_time = time.time()
-    timeout = 300
-    while time.time() - start_time < timeout:
-        current_common_name = get_vault_pki_intermediate_ca_common_name(root_token, endpoint, mount)
-        if current_common_name == expected_common_name:
-            return current_common_name
-        time.sleep(10)
-    raise TimeoutError("Timed out waiting issuer config to update in Vault.")
 
 def get_vault_pki_intermediate_ca_common_name(root_token: str, endpoint: str, mount: str) -> str:
     client = hvac.Client(url=f"https://{endpoint}:8200", verify=False)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -439,11 +439,10 @@ class TestVaultK8sIntegrationsPart1:
 
         leader_unit_index, root_token, _ = deployed_vault_initialized_leader
         unit_addresses = [row["address"] for row in await read_vault_unit_statuses(ops_test)]
-        current_issuers_common_name = wait_for_vault_pki_issuer_config_update(
+        current_issuers_common_name = get_vault_pki_intermediate_ca_common_name(
             root_token=root_token,
             endpoint=unit_addresses[leader_unit_index],
             mount="charm-pki",
-            expected_common_name=common_name,
         )
         action_output = await run_get_certificate_action(ops_test)
         assert current_issuers_common_name == common_name
@@ -1092,18 +1091,6 @@ async def authorize_charm(
         action_uuid=authorize_action.entity_id, wait=120
     )
     return result
-
-
-def wait_for_vault_pki_issuer_config_update(root_token: str, endpoint: str, mount: str, expected_common_name: str) -> str:
-    start_time = time.time()
-    timeout = 300
-    while time.time() - start_time < timeout:
-        current_common_name = get_vault_pki_intermediate_ca_common_name(root_token, endpoint, mount)
-        if current_common_name == expected_common_name:
-            return current_common_name
-        time.sleep(10)
-    raise TimeoutError("Timed out waiting issuer config to update in Vault.")
-
 
 def get_vault_pki_intermediate_ca_common_name(root_token: str, endpoint: str, mount: str) -> str:
     client = hvac.Client(url=f"https://{endpoint}:8200", verify=False)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -416,18 +416,19 @@ class TestVaultK8sIntegrationsPart1:
         }
         await vault_app.set_config(common_name_config)
         leader_unit_index, root_token, _ = initialize_leader_vault
+        unit_addresses = [row["address"] for row in await read_vault_unit_statuses(ops_test)]
+        current_issuers_common_name = wait_for_vault_pki_issuer_config_update(
+            root_token=root_token,
+            endpoint=unit_addresses[leader_unit_index],
+            mount="charm-pki",
+            expected_common_name=common_name,
+        )
         await ops_test.model.wait_for_idle(
             apps=[APPLICATION_NAME, VAULT_PKI_REQUIRER_APPLICATION_NAME],
             status="active",
             timeout=1000,
         )
         action_output = await run_get_certificate_action(ops_test)
-        unit_addresses = [row["address"] for row in await read_vault_unit_statuses(ops_test)]
-        current_issuers_common_name = get_vault_pki_intermediate_ca_common_name(
-            root_token=root_token,
-            endpoint=unit_addresses[leader_unit_index],
-            mount="charm-pki",
-        )
         assert current_issuers_common_name == common_name
         assert action_output["certificate"] is not None
         assert action_output["ca-certificate"] is not None
@@ -958,6 +959,16 @@ async def authorize_charm(ops_test: OpsTest, root_token: str) -> Any | Dict:
         action_uuid=authorize_action.entity_id, wait=120
     )
     return result
+
+def wait_for_vault_pki_issuer_config_update(root_token: str, endpoint: str, mount: str, expected_common_name: str) -> str:
+    start_time = time.time()
+    timeout = 300
+    while time.time() - start_time < timeout:
+        current_common_name = get_vault_pki_intermediate_ca_common_name(root_token, endpoint, mount)
+        if current_common_name == expected_common_name:
+            return current_common_name
+        time.sleep(10)
+    raise TimeoutError("Timed out waiting issuer config to update in Vault.")
 
 def get_vault_pki_intermediate_ca_common_name(root_token: str, endpoint: str, mount: str) -> str:
     client = hvac.Client(url=f"https://{endpoint}:8200", verify=False)


### PR DESCRIPTION
# Description

- We validate that the issuers config is not yet updated before updating it again. This should prevent us from writing to that config more than once avoiding any unexpected behaviour.
- The integration test changes introduced in #386 made the CI unstable. The changes in the issuers config might not be immediately visible in vault, for that in this PR we wait until all units are active idle (that indicates that the Vault API is available again).


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
