### PR TITLE
chore: add self hosted runners to integration tests

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -5,10 +5,7 @@ on:
 
 jobs:
   integration-test:
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      matrix:
-        runner: [ubuntu-22.04, [self-hosted, linux, X64, jammy, large]]
+    runs-on: [self-hosted, linux, X64, jammy, large]
 
     steps:
       - name: Checkout

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -5,7 +5,11 @@ on:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner: [ubuntu-22.04, [self-hosted, linux, X64, jammy, large]]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   integration-test:
-    runs-on: [self-hosted, linux, X64, jammy, large]
+    runs-on: [self-hosted, linux, X64, xlarge, jammy]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# Description

We use selfhosted runners to have more space to do our integration tests

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
