### PR TITLE
feat: Include the mount_path in the autounseal databag

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_autounseal.py
+++ b/lib/charms/vault_k8s/v0/vault_autounseal.py
@@ -79,7 +79,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 class LogAdapter(logging.LoggerAdapter):

--- a/src/charm.py
+++ b/src/charm.py
@@ -107,6 +107,7 @@ class AutounsealConfigurationDetails:
     """Credentials required for configuring auto-unseal on Vault."""
 
     address: str
+    mount_path: str
     key_name: str
     token: str
     ca_cert_path: str
@@ -290,6 +291,7 @@ class VaultCharm(CharmBase):
         self.vault_autounseal_provides.set_autounseal_data(
             relation,
             vault_address,
+            AUTOUNSEAL_MOUNT_PATH,
             key_name,
             approle_id,
             approle_secret_id,
@@ -1128,6 +1130,7 @@ class VaultCharm(CharmBase):
 
         return AutounsealConfigurationDetails(
             autounseal_details.address,
+            autounseal_details.mount_path,
             autounseal_details.key_name,
             self._get_autounseal_vault_token(autounseal_details),
             self.tls.get_tls_file_path_in_workload(File.AUTOUNSEAL_CA),
@@ -1504,7 +1507,7 @@ def _render_vault_config_file(
         retry_joins=retry_joins,
         autounseal_address=autounseal_details.address if autounseal_details else None,
         autounseal_key_name=autounseal_details.key_name if autounseal_details else None,
-        autounseal_mount_path=AUTOUNSEAL_MOUNT_PATH if autounseal_details else None,
+        autounseal_mount_path=autounseal_details.mount_path if autounseal_details else None,
         autounseal_token=autounseal_details.token if autounseal_details else None,
         autounseal_tls_ca_cert=autounseal_details.ca_cert_path if autounseal_details else None,
     )

--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_autounseal.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_autounseal.py
@@ -19,6 +19,7 @@ from ops.charm import CharmBase
 
 AUTOUNSEAL_PROVIDES_RELATION_NAME = "vault-autounseal-provides"
 AUTOUNSEAL_REQUIRES_RELATION_NAME = "vault-autounseal-requires"
+AUTOUNSEAL_MOUNT_PATH = "charm-autounseal"
 
 
 class VaultAutounsealProviderCharm(CharmBase):
@@ -119,11 +120,18 @@ class TestVaultAutounsealProvides(unittest.TestCase):
         mock_add_secret.return_value = MagicMock(**{"id": "some secret id"})
 
         self.harness.charm.interface.set_autounseal_data(
-            relation, vault_address, key_name, approle_id, approle_secret_id, ca_certificate
+            relation,
+            vault_address,
+            AUTOUNSEAL_MOUNT_PATH,
+            key_name,
+            approle_id,
+            approle_secret_id,
+            ca_certificate,
         )
         mock_add_secret.assert_called_once()
         assert self.harness.get_relation_data(relation.id, self.harness.charm.app.name) == {
             "address": vault_address,
+            "mount_path": AUTOUNSEAL_MOUNT_PATH,
             "key_name": key_name,
             "credentials_secret_id": "some secret id",
             "ca_certificate": ca_certificate,
@@ -140,7 +148,13 @@ class TestVaultAutounsealProvides(unittest.TestCase):
         ca_certificate = "my ca certificate"
 
         self.harness.charm.interface.set_autounseal_data(
-            relation, vault_address, key_name, approle_id, approle_secret_id, ca_certificate
+            relation,
+            vault_address,
+            AUTOUNSEAL_MOUNT_PATH,
+            key_name,
+            approle_id,
+            approle_secret_id,
+            ca_certificate,
         )
         assert self.harness.get_relation_data(relation.id, self.harness.charm.app.name) == {}
 
@@ -297,6 +311,7 @@ class TestVaultAutounsealRequires(unittest.TestCase):
             remote_app,
             {
                 "address": vault_url,
+                "mount_path": AUTOUNSEAL_MOUNT_PATH,
                 "key_name": key_name,
                 "credentials_secret_id": credentials_secret_id,
                 "ca_certificate": ca_certificate,
@@ -308,6 +323,7 @@ class TestVaultAutounsealRequires(unittest.TestCase):
 
         assert isinstance(event, VaultAutounsealDetailsReadyEvent)
         assert event.address == vault_url
+        assert event.mount_path == AUTOUNSEAL_MOUNT_PATH
         assert event.key_name == key_name
         assert event.role_id == role_id
         assert event.secret_id == secret_id
@@ -348,6 +364,7 @@ class TestVaultAutounsealRequires(unittest.TestCase):
             remote_app,
             {
                 "address": vault_url,
+                "mount_path": AUTOUNSEAL_MOUNT_PATH,
                 "key_name": key_name,
                 "credentials_secret_id": credentials_secret_id,
                 "ca_certificate": ca_certificate,
@@ -357,7 +374,7 @@ class TestVaultAutounsealRequires(unittest.TestCase):
         details = self.harness.charm.interface.get_details()
 
         assert details == AutounsealDetails(
-            vault_url, key_name, role_id, secret_id, ca_certificate
+            vault_url, AUTOUNSEAL_MOUNT_PATH, key_name, role_id, secret_id, ca_certificate
         )
 
     def test_given_no_details_when_get_details_then_none_is_returned(self):


### PR DESCRIPTION
There's no need to infer this, and adding it makes the interface more flexible.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
