### PR TITLE
feat: Use juju secrets instead for authorize-charm

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -126,15 +126,17 @@ actions:
     description: >-
       Authorizes the charm to be able to interact with Vault to manage its
       operations. A token is required for Vault to use to create the app role and
-      the policy the charm will use to interact with Vault.
+      the policy the charm will use to interact with Vault. This token must be
+      placed in juju secret, and this secret should be granted to the charm.
     params:
-      token:
+      secret-id:
         type: string
         description: >-
-          A token for Vault that can create new policies, such as the root token
-          that is provided upon initializing Vault. Used to create the app role
-          and policy for the charm. It is not stored by the charm.
-    required: [token] 
+          A secret id from juju that contains a token for Vault that can create 
+          new policies, such as the root token that is provided upon initializing 
+          Vault. Used to create the app role and policy for the charm. It is not
+          stored by the charm.
+    required: [secret-id] 
 
   create-backup:
     description: >-

--- a/src/charm.py
+++ b/src/charm.py
@@ -706,14 +706,18 @@ class VaultCharm(CharmBase):
             token_secret = self.model.get_secret(id=secret_id)
             token = token_secret.get_content(refresh=True).get("token", "")
         except SecretNotFoundError:
-            event.fail("The secret id provided is not available to the charm.")
+            event.fail(
+                "The secret id provided could not be found by the charm. Please grant the token secret to the charm."
+            )
             return
 
         vault = Vault(self._api_address, self.tls.get_tls_file_path_in_charm(File.CA))
         vault.authenticate(Token(token))
 
         if not vault.get_token_data():
-            event.fail("The token provided is not valid.")
+            event.fail(
+                "The token provided is not valid. Please use a Vault token with the appropriate permissions."
+            )
             return
 
         try:
@@ -734,7 +738,9 @@ class VaultCharm(CharmBase):
                 {"role-id": role_id, "secret-id": secret_id},
                 description="The authentication details for the charm's access to vault.",
             )
-            event.set_results({"result": "Charm authorized successfully."})
+            event.set_results(
+                {"result": "Charm authorized successfully. You may now remove the secret."}
+            )
         except VaultClientError as e:
             logger.exception("Vault returned an error while authorizing the charm")
             event.fail(f"Vault returned an error while authorizing the charm: {str(e)}")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1081,10 +1081,13 @@ async def authorize_charm(
 ) -> Any | Dict:
     assert ops_test.model
     leader_unit = await get_leader_unit(ops_test.model, app_name)
+    secret = await ops_test.model.add_secret(f"approle-token-{app_name}", [f"token={root_token}"])
+    secret_id = secret.split(":")[-1]
+    await ops_test.model.grant_secret(f"approle-token-{app_name}", app_name)
     authorize_action = await leader_unit.run_action(
         action_name="authorize-charm",
         **{
-            "token": root_token,
+            "secret-id": secret_id,
         },
     )
     result = await ops_test.model.get_action_output(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -579,7 +579,10 @@ class TestCharm(unittest.TestCase):
 
         assert secret_content["role-id"] == "approle_id"
         assert secret_content["secret-id"] == "secret_id"
-        assert action_result["result"] == "Charm authorized successfully."
+        assert (
+            action_result["result"]
+            == "Charm authorized successfully. You may now remove the secret."
+        )
 
     def test_given_unit_is_not_leader_when_authorize_charm_then_action_fails(
         self,
@@ -610,7 +613,10 @@ class TestCharm(unittest.TestCase):
 
         with self.assertRaises(testing.ActionFailed) as e:
             self.harness.run_action("authorize-charm", {"secret-id": token_secret_id})
-        self.assertEqual(e.exception.message, "The token provided is not valid.")
+        self.assertEqual(
+            e.exception.message,
+            "The token provided is not valid. Please use a Vault token with the appropriate permissions.",
+        )
 
     def test_given_unit_is_leader_and_secret_not_provided_when_authorize_charm_then_action_fails(
         self,
@@ -633,7 +639,8 @@ class TestCharm(unittest.TestCase):
         with self.assertRaises(testing.ActionFailed) as e:
             self.harness.run_action("authorize-charm", {"secret-id": "somesecretid"})
         self.assertEqual(
-            e.exception.message, "The secret id provided is not available to the charm."
+            e.exception.message,
+            "The secret id provided could not be found by the charm. Please grant the token secret to the charm.",
         )
 
     # Test remove

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -151,6 +151,19 @@ class TestCharm(unittest.TestCase):
         """Set the peer relation and return the relation id."""
         return self.harness.add_relation(relation_name="vault-peers", remote_app=self.app_name)
 
+    def _set_root_token_secret(self, token: str = "some token") -> str:
+        """Set the root token secret."""
+        content = {
+            "token": token,
+        }
+        original_leader_state = self.harness.charm.unit.is_leader()
+        with self.harness.hooks_disabled():
+            self.harness.set_leader(is_leader=True)
+            secret_id = self.harness.add_user_secret(content=content)
+            self.harness.grant_secret(secret_id, self.app_name)
+            self.harness.set_leader(original_leader_state)
+        return secret_id
+
     def _set_approle_secret(self, role_id: str, secret_id: str) -> None:
         """Set the approle secret."""
         content = {
@@ -524,6 +537,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader()
         peer_relation_id = self._set_peer_relation()
         other_unit_name = f"{self.harness.charm.app.name}/1"
+        token_secret_id = self._set_root_token_secret("test-token")
         self.harness.add_relation_unit(
             relation_id=peer_relation_id, remote_unit_name=other_unit_name
         )
@@ -536,7 +550,9 @@ class TestCharm(unittest.TestCase):
             },
         )
 
-        action_result = self.harness.run_action("authorize-charm", {"token": "test-token"}).results
+        action_result = self.harness.run_action(
+            "authorize-charm", {"secret-id": token_secret_id}
+        ).results
 
         self.mock_vault.authenticate.assert_called_once_with(Token("test-token"))
         self.mock_vault.enable_audit_device.assert_called_once_with(
@@ -569,12 +585,34 @@ class TestCharm(unittest.TestCase):
         self,
     ):
         self.harness.set_leader(False)
-        try:
-            self.harness.run_action("authorize-charm", {"token": "test-token"})
-        except testing.ActionFailed as e:
-            self.assertEqual(e.message, "This action must be run on the leader unit.")
+        with self.assertRaises(testing.ActionFailed) as e:
+            self.harness.run_action("authorize-charm", {"secret-id": "secret"})
+            self.assertEqual(e.exception.message, "This action must be run on the leader unit.")
 
     def test_given_unit_is_leader_and_token_is_invalid_when_authorize_charm_then_action_fails(
+        self,
+    ):
+        self.harness.set_leader()
+        peer_relation_id = self._set_peer_relation()
+        other_unit_name = f"{self.harness.charm.app.name}/1"
+        token_secret_id = self._set_root_token_secret()
+        self.harness.add_relation_unit(
+            relation_id=peer_relation_id, remote_unit_name=other_unit_name
+        )
+
+        self.mock_vault.configure_mock(
+            **{
+                "get_token_data.return_value": None,
+                "configure_approle.return_value": "approle_id",
+                "generate_role_secret_id.return_value": "secret_id",
+            },
+        )
+
+        with self.assertRaises(testing.ActionFailed) as e:
+            self.harness.run_action("authorize-charm", {"secret-id": token_secret_id})
+        self.assertEqual(e.exception.message, "The token provided is not valid.")
+
+    def test_given_unit_is_leader_and_secret_not_provided_when_authorize_charm_then_action_fails(
         self,
     ):
         self.harness.set_leader()
@@ -592,10 +630,11 @@ class TestCharm(unittest.TestCase):
             },
         )
 
-        try:
-            self.harness.run_action("authorize-charm", {"token": "test-token"})
-        except testing.ActionFailed as e:
-            self.assertEqual(e.message, "The token provided is not valid.")
+        with self.assertRaises(testing.ActionFailed) as e:
+            self.harness.run_action("authorize-charm", {"secret-id": "somesecretid"})
+        self.assertEqual(
+            e.exception.message, "The secret id provided is not available to the charm."
+        )
 
     # Test remove
     def test_given_can_connect_when_on_remove_then_raft_storage_path_is_deleted(self):


### PR DESCRIPTION
# Description

This change includes moving from using an action to authorize the charm to granting a user secret to authorizing a charm. The process is simply:
```shell
juju add-secret approle_authorization_token token=$VAULT_TOKEN
juju grant-secret approle_authorization_token vault-k8s
juju run vault/leader authorize-charm secret-id=$secret-id
```

The documentation will need to be updated.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
