### PR TITLE
chore: Tracks Vault 1.16 on main branch

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -38,6 +38,6 @@ jobs:
           base-channel: 22.04
           credentials: ${{ secrets.CHARMCRAFT_AUTH }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          destination-channel: 1.15/${{ env.promote-to }}
-          origin-channel: 1.15/${{ env.promote-from }}
+          destination-channel: 1.16/${{ env.promote-to }}
+          origin-channel: 1.16/${{ env.promote-from }}
           charmcraft-channel: latest/stable

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -20,25 +20,25 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: built-charm
-      
+
       - name: Get Charm Under Test Path
         id: charm-path
         run: echo "charm_path=$(find . -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
-  
+
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.6.0
         with:
           built-charm-path: ${{ steps.charm-path.outputs.charm_path }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: 1.15/edge
-  
+          channel: 1.16/edge
+
       - name: Publish libs
         uses: canonical/charming-actions/release-libraries@2.6.0
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-  
+
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -39,7 +39,7 @@ resources:
   vault-image:
     type: oci-image
     description: OCI image for Vault
-    upstream-source: ghcr.io/canonical/vault:1.15.6
+    upstream-source: ghcr.io/canonical/vault:1.16.3
 
 storage:
   vault-raft:


### PR DESCRIPTION
# Description

When #373 is merged Vault `1.15` should be tracked by the `release-1.15` release branch and Vault `1.16` will be tracked by main.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
