### PR TITLE
chore: Grafana dashboards should not be editable

### DIFF
--- a/src/grafana_dashboards/vault.json
+++ b/src/grafana_dashboards/vault.json
@@ -16,7 +16,7 @@
         ]
     },
     "description": "Vault Metrics",
-    "editable": true,
+    "editable": false,
     "fiscalYearStartMonth": 0,
     "gnetId": 12904,
     "graphTooltip": 1,


### PR DESCRIPTION
Without this, we get `[❌] Dashboard 'Vault' is editable, it should be set to 'editable: false'` and the test fails.

I'm honestly not sure what the implications of this are, I'm just listening to the linter here. Pinging @gruyaume because you wrote this check, so hopefully you have a bit more context.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
