### PR TITLE
feat: enable dead server pruning

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -26,7 +26,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 14
+LIBPATCH = 15
 
 
 RAFT_STATE_ENDPOINT = "v1/sys/storage/raft/autopilot/state"
@@ -440,6 +440,26 @@ class Vault:
         """Get raft cluster state."""
         response = self._client.adapter.get(RAFT_STATE_ENDPOINT)
         return response["data"]
+
+    def update_autopilot_config(self) -> None:
+        """Set Vault to clean up dead servers automatically.
+
+        Read more about it here: https://developer.hashicorp.com/vault/api-docs/system/storage/raftautopilot#set-configuration
+
+        """
+        params = {
+            "cleanup_dead_servers": True,
+            "dead_server_last_contact_threshold": "1m",
+            "min_quorum": 3,
+        }
+        api_path = "/v1/sys/storage/raft/autopilot/configuration"
+        try:
+            self._client.adapter.post(
+                url=api_path,
+                json=params,
+            )
+        except InvalidRequest as e:
+            raise VaultClientError(e) from e
 
     def is_raft_cluster_healthy(self) -> bool:
         """Check if raft cluster is healthy."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -722,6 +722,7 @@ class VaultCharm(CharmBase):
 
         try:
             vault.enable_audit_device(device_type=AuditDeviceType.FILE, path="stdout")
+            vault.update_autopilot_config()
             vault.enable_approle_auth_method()
             vault.configure_policy(policy_name=CHARM_POLICY_NAME, policy_path=CHARM_POLICY_PATH)
             cidrs = [f"{self._bind_address}/24"]


### PR DESCRIPTION
# Description

This PR introduces a change that [configures the raft backend](https://developer.hashicorp.com/vault/api-docs/system/storage/raftautopilot#set-configuration) when the charm is being authorized. These configuration options do not have a relevant field in the vault.hcl config file, so they have to be executed (relatively) manually.

Vault only allows a minimum of 3 for the minimum quorum for automatic dead server pruning. This means that dead server 2 and 3 will never be cleaned. On top of that, we already do our best to update the vault config file and remove the peers that are not planned to be there, so this is really a plan C thing.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
