### PR TITLE
test: PKI requirer as optional test parameter

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,6 +24,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=None,
         help="Path to the KV requirer charm",
     )
+    parser.addoption(
+        "--pki_requirer_charm_path",
+        action="store",
+        default=None,
+        help="Path to the PKI requirer charm",
+    )
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -239,8 +239,14 @@ class TestVaultK8sIntegrationsPart1:
             application_name=VAULT_KV_REQUIRER_APPLICATION_NAME,
             num_units=1,
         )
+        pki_requirer_charm_path = request.config.getoption(
+            "--pki_requirer_charm_path", default=None
+        )
+
         deploy_vault_pki_requirer = ops_test.model.deploy(
-            VAULT_PKI_REQUIRER_APPLICATION_NAME,
+            Path(pki_requirer_charm_path).resolve()
+            if pki_requirer_charm_path
+            else VAULT_PKI_REQUIRER_APPLICATION_NAME,
             application_name=VAULT_PKI_REQUIRER_APPLICATION_NAME,
             channel="stable",
             config={"common_name": "test.example.com"},


### PR DESCRIPTION
Allow passing the PKI requirer as an optional parameter when running the integration tests.

This was useful when debugging and preparing fixes in tls-requirer-operator. Presumably, it will be useful again in the future.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
