### PR TITLE
refactor: Downgrade log to warning level

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -26,7 +26,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 14
+LIBPATCH = 15
 
 
 RAFT_STATE_ENDPOINT = "v1/sys/storage/raft/autopilot/state"
@@ -470,7 +470,7 @@ class Vault:
                 name=role, mount_point=mount
             ).get("data", {}).get("allowed_domains", [])
         except InvalidPath:
-            logger.error("Role does not exist on the specified path.")
+            logger.warning("Role does not exist on the specified path.")
             return False
 
     def make_latest_pki_issuer_default(self, mount: str) -> None:


### PR DESCRIPTION
This isn't an error. It is actually expected in normal operation of the charm, and the error logs are misleading.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
