### PR TITLE
chore: only log when action is completed

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_tls.py
+++ b/lib/charms/vault_k8s/v0/vault_tls.py
@@ -33,7 +33,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 
 class LogAdapter(logging.LoggerAdapter):
@@ -229,11 +229,11 @@ class VaultTLSManager(Object):
                 self.certificate_transfer.set_certificate(
                     certificate="", ca=ca, chain=[], relation_id=relation.id
                 )
-            logger.info("Sent CA certificate to other relations")
+                logger.info("Sent CA certificate to relation %s", relation.id)
         else:
             for relation in self.charm.model.relations.get(SEND_CA_CERT_RELATION_NAME, []):
                 self.certificate_transfer.remove_certificate(relation.id)
-            logger.info("Removed CA cert from relations")
+                logger.info("Removed CA cert from relation %s", relation.id)
 
     def _generate_self_signed_certs(self, subject_ip: str) -> None:
         """Recreate a unit certificate from the Vault CA certificate, then saves it.


### PR DESCRIPTION
# Description

The logs for Vault charms contain many instances of the `Sent CA certificate to other relations`, even when this relation does not exist. We should only log when the actual action was completed.

## Logs

```
unit-vault-2: 13:23:53 INFO unit.vault/2.juju-log [vault_tls] Sent CA certificate to other relations
unit-vault-2: 13:23:54 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
unit-vault-0: 13:23:59 INFO unit.vault/0.juju-log [vault_tls] Sent CA certificate to other relations
unit-vault-1: 13:23:59 INFO unit.vault/1.juju-log [vault_tls] Sent CA certificate to other relations
unit-vault-0: 13:23:59 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
unit-vault-1: 13:23:59 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
unit-vault-2: 13:24:04 INFO unit.vault/2.juju-log [vault_tls] Sent CA certificate to other relations
unit-vault-2: 13:24:05 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
unit-vault-1: 13:24:08 INFO unit.vault/1.juju-log [vault_tls] Sent CA certificate to other relations
unit-vault-1: 13:24:09 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
unit-vault-0: 13:24:10 INFO unit.vault/0.juju-log [vault_tls] Sent CA certificate to other relations
unit-vault-0: 13:24:10 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
unit-vault-2: 13:24:13 INFO unit.vault/2.juju-log [vault_tls] Sent CA certificate to other relations
unit-vault-2: 13:24:14 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
unit-vault-1: 13:24:19 INFO unit.vault/1.juju-log [vault_tls] Sent CA certificate to other relations
unit-vault-1: 13:24:20 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
unit-vault-0: 13:24:21 INFO unit.vault/0.juju-log [vault_tls] Sent CA certificate to other relations
unit-vault-0: 13:24:22 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
unit-vault-2: 13:24:23 INFO unit.vault/2.juju-log [vault_tls] Sent CA certificate to other relations
unit-vault-2: 13:24:23 INFO juju.worker.uniter.operation ran "update-status" hook (via hook dispatching script: dispatch)
```
# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
