### PR TITLE
feat(kv): support wrap-ttl on vault-kv interface

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -303,6 +303,15 @@ class Vault:
         response = self._client.auth.approle.generate_secret_id(name, cidr_list=cidrs)
         return response["data"]["secret_id"]
 
+    def generate_role_wrapping_token(
+        self, name: str, wrap_ttl: int, cidrs: Optional[List[str]] = None
+    ) -> str:
+        """Generate a new wrapping token tied to an AppRole."""
+        response = self._client.auth.approle.generate_secret_id(
+            name, cidr_list=cidrs, wrap_ttl=wrap_ttl
+        )
+        return response["wrap_info"]["token"]
+
     def read_role_secret(self, name: str, id: str) -> dict:
         """Get definition of a secret tied to an AppRole."""
         response = self._client.auth.approle.read_secret_id(name, id)

--- a/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/lib/charms/vault_k8s/v0/vault_kv.py
@@ -179,6 +179,15 @@ class AppVaultKvRequirerSchema(BaseModel):
     mount_suffix: str = Field(
         description="Suffix to append to the mount name to get the KV mount."
     )
+    wrap_ttl: Optional[int] = Field(
+        default=None,
+        title="Wrap TTL",
+        description=(
+            "Whether to request approle secret_id as a response-wrapping token with a certain TTL."
+            " If not set, no wrapping will be made to secret_id. Otherwise, wrap_ttl specifies"
+            " the duration of seconds before the expiration of the response-wrapping token."
+        ),
+    )
 
 
 class UnitVaultKvRequirerSchema(BaseModel):
@@ -215,7 +224,7 @@ class KVRequest:
     nonce: str
 
 
-def is_requirer_data_valid(app_data: Mapping[str, str], unit_data: Mapping[str, str]) -> bool:
+def is_requirer_data_valid(app_data: Mapping[str, Any], unit_data: Mapping[str, str]) -> bool:
     """Return whether the requirer data is valid."""
     try:
         RequirerSchema(


### PR DESCRIPTION
# Description

The `vault-kv` interface can support wrapping responses of approle secret-id. This PR:

- enables the vault_kv library to allow requirers to set `wrap_ttl` to relation data
- adds `generate_role_wrapping_token` helper function on `vault_client`

Depends-on: https://github.com/canonical/charm-relation-interfaces/pull/155

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
