### PR TITLE
fix: Adds a workaround to avoid changing relation data when kv secret id formatting changes

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/lib/charms/vault_k8s/v0/vault_kv.py
@@ -379,7 +379,9 @@ class VaultKvProvides(ops.Object):
                 nonce,
             )
             return
-        standard_secret_id = secret.id[len("secret:"):] if secret.id.startswith("secret:") else secret.id
+        standard_secret_id = (
+            secret.id[len("secret:") :] if secret.id.startswith("secret:") else secret.id
+        )
         if standard_secret_id in credentials.get(nonce, ""):
             logger.debug(
                 "Secret id has not changed, not updating the relation '%s:%d' for nonce %r",

--- a/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/lib/charms/vault_k8s/v0/vault_kv.py
@@ -133,7 +133,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 
@@ -374,6 +374,15 @@ class VaultKvProvides(ops.Object):
         if secret.id is None:
             logger.debug(
                 "Secret id is None, not updating the relation '%s:%d' for nonce %r",
+                relation.name,
+                relation.id,
+                nonce,
+            )
+            return
+        standard_secret_id = secret.id[len("secret:"):] if secret.id.startswith("secret:") else secret.id
+        if standard_secret_id in credentials.get(nonce, ""):
+            logger.debug(
+                "Secret id has not changed, not updating the relation '%s:%d' for nonce %r",
                 relation.name,
                 relation.id,
                 nonce,

--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_kv.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_kv.py
@@ -216,7 +216,7 @@ class TestVaultKvProvides(unittest.TestCase):
             self.harness.get_relation_data(rel_id, self.harness.charm.app.name)["credentials"]
         ) == {unit_name: secret.id}
 
-        with self.assertLogs(level='DEBUG') as log:
+        with self.assertLogs(level="DEBUG") as log:
             self.harness.charm.interface.set_unit_credentials(relation, unit_name, secret)
         self.assertIn("Secret id has not changed, not updating the relation", log.output[0])
 


### PR DESCRIPTION
# Description

fixes https://github.com/canonical/vault-operator/issues/243

In case of cross model relations when the kv secret is created it has the format `secret://modeluuid/secretid`.
However when the secret is updated using the `set_content` function the id format becomes `secret://secretid` which is not usable in cross model relation, we add a workaround not to update the relation data with this new format.
A bug will be reported in Juju.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
