### PR TITLE
fix: Uses egress subnet list to configure approle

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/lib/charms/vault_k8s/v0/vault_kv.py
@@ -94,7 +94,7 @@ class ExampleRequirerCharm(CharmBase):
         # Update status might not be the best place
         binding = self.model.get_binding("vault-kv")
         if binding is not None:
-            egress_subnet = str(binding.network.interfaces[0].subnet)
+            egress_subnet = [str(subnet) for subnet in self.model.get_binding(relation).network.egress_subnets][0].subnet]
             relation = self.model.get_relation(relation_name="vault-kv")
             self.interface.request_credentials(relation, egress_subnet, self.get_nonce())
 

--- a/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/lib/charms/vault_k8s/v0/vault_kv.py
@@ -219,6 +219,18 @@ class KVRequest:
     nonce: str
 
 
+def get_egress_subnets_list_from_relation_data(relation_databag: Mapping[str, str]) -> List[str]:
+    """Return the egress_subnet as a list.
+
+    This function converts the string with values separated by commas to a list.
+
+    Args:
+        relation_databag: the relation databag of the unit or the app.
+    """
+    print(type(relation_databag))
+    return [subnet.strip() for subnet in relation_databag.get("egress_subnet", "").split(",")]
+
+
 def is_requirer_data_valid(app_data: Mapping[str, str], unit_data: Mapping[str, str]) -> bool:
     """Return whether the requirer data is valid."""
     try:
@@ -339,7 +351,9 @@ class VaultKvProvides(ops.Object):
                 app_name=event.app.name,
                 unit_name=unit.name,
                 mount_suffix=event.relation.data[event.app]["mount_suffix"],
-                egress_subnets=event.relation.data[unit]["egress_subnet"].split(","),
+                egress_subnets=get_egress_subnets_list_from_relation_data(
+                    event.relation.data[unit]
+                ),
                 nonce=event.relation.data[unit]["nonce"],
             )
 
@@ -458,7 +472,7 @@ class VaultKvProvides(ops.Object):
                         app_name=relation.app.name,
                         unit_name=unit.name,
                         mount_suffix=app_data["mount_suffix"],
-                        egress_subnets=unit_data["egress_subnet"].split(","),
+                        egress_subnets=get_egress_subnets_list_from_relation_data(unit_data),
                         nonce=unit_data["nonce"],
                     )
                 )

--- a/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/lib/charms/vault_k8s/v0/vault_kv.py
@@ -227,7 +227,6 @@ def get_egress_subnets_list_from_relation_data(relation_databag: Mapping[str, st
     Args:
         relation_databag: the relation databag of the unit or the app.
     """
-    print(type(relation_databag))
     return [subnet.strip() for subnet in relation_databag.get("egress_subnet", "").split(",")]
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -462,7 +462,7 @@ class VaultCharm(CharmBase):
             app_name=event.app_name,
             unit_name=event.unit_name,
             mount_suffix=event.mount_suffix,
-            egress_subnet=event.egress_subnet,
+            egress_subnets=event.egress_subnets,
             nonce=event.nonce,
         )
 
@@ -607,7 +607,7 @@ class VaultCharm(CharmBase):
                 app_name=kv_request.app_name,
                 unit_name=kv_request.unit_name,
                 mount_suffix=kv_request.mount_suffix,
-                egress_subnet=kv_request.egress_subnet,
+                egress_subnets=kv_request.egress_subnets,
                 nonce=kv_request.nonce,
             )
 
@@ -617,7 +617,7 @@ class VaultCharm(CharmBase):
         app_name: str,
         unit_name: str,
         mount_suffix: str,
-        egress_subnet: List[str],
+        egress_subnets: List[str],
         nonce: str,
     ):
         if not self.unit.is_leader():
@@ -633,8 +633,8 @@ class VaultCharm(CharmBase):
             return
         mount = f"charm-{app_name}-{mount_suffix}"
         vault.enable_secrets_engine(SecretsBackend.KV_V2, mount)
-        self._ensure_unit_credentials(vault, relation, unit_name, mount, nonce, egress_subnet)
-        self._set_kv_relation_data(relation, mount, ca_certificate, egress_subnet)
+        self._ensure_unit_credentials(vault, relation, unit_name, mount, nonce, egress_subnets)
+        self._set_kv_relation_data(relation, mount, ca_certificate, egress_subnets)
         self._remove_stale_nonce(relation=relation, nonce=nonce)
 
     def _get_pki_ca_certificate(self) -> Optional[str]:
@@ -934,7 +934,7 @@ class VaultCharm(CharmBase):
         relation: Relation,
         mount: str,
         ca_certificate: str,
-        egress_subnet: List[str],
+        egress_subnets: List[str],
     ) -> None:
         """Set relation data for vault-kv.
 
@@ -942,12 +942,12 @@ class VaultCharm(CharmBase):
             relation: Relation
             mount: mount name
             ca_certificate: CA certificate
-            egress_subnet: egress subnet
+            egress_subnets: egress subnet
         """
         self.vault_kv.set_mount(relation, mount)
         vault_url = self._get_relation_api_address(relation)
         self.vault_kv.set_ca_certificate(relation, ca_certificate)
-        self.vault_kv.set_egress_subnet(relation, egress_subnet)
+        self.vault_kv.set_egress_subnets(relation, egress_subnets)
         if vault_url is not None:
             self.vault_kv.set_vault_url(relation, vault_url)
 
@@ -958,7 +958,7 @@ class VaultCharm(CharmBase):
         unit_name: str,
         mount: str,
         nonce: str,
-        egress_subnet: List[str],
+        egress_subnets: List[str],
     ):
         """Ensure a unit has credentials to access the vault-kv mount."""
         policy_name = role_name = mount + "-" + unit_name.replace("/", "-")
@@ -966,7 +966,7 @@ class VaultCharm(CharmBase):
         role_id = vault.configure_approle(
             role_name,
             policies=[policy_name],
-            cidrs=egress_subnet,
+            cidrs=egress_subnets,
             token_ttl="1h",
             token_max_ttl="1h",
         )
@@ -975,7 +975,7 @@ class VaultCharm(CharmBase):
             relation,
             role_id,
             role_name,
-            egress_subnet,
+            egress_subnets,
         )
         self.vault_kv.set_unit_credentials(relation, nonce, secret)
 
@@ -985,7 +985,7 @@ class VaultCharm(CharmBase):
         relation: Relation,
         role_id: str,
         role_name: str,
-        egress_subnet: List[str],
+        egress_subnets: List[str],
     ) -> Secret:
         """Create or update a KV secret for a unit.
 
@@ -996,11 +996,11 @@ class VaultCharm(CharmBase):
         secret_id = self._get_vault_kv_secret_in_peer_relation(label)
         if secret_id is None:
             return self._create_kv_secret(
-                vault, relation, role_id, role_name, egress_subnet, label
+                vault, relation, role_id, role_name, egress_subnets, label
             )
         else:
             return self._update_kv_secret(
-                vault, relation, role_name, egress_subnet, label, secret_id
+                vault, relation, role_name, egress_subnets, label, secret_id
             )
 
     def _create_kv_secret(
@@ -1009,11 +1009,11 @@ class VaultCharm(CharmBase):
         relation: Relation,
         role_id: str,
         role_name: str,
-        egress_subnet: List[str],
+        egress_subnets: List[str],
         label: str,
     ) -> Secret:
         """Create a vault kv secret, store its id in the peer relation and return it."""
-        role_secret_id = vault.generate_role_secret_id(role_name, egress_subnet)
+        role_secret_id = vault.generate_role_secret_id(role_name, egress_subnets)
         secret = self.app.add_secret(
             {"role-id": role_id, "role-secret-id": role_secret_id},
             label=label,
@@ -1029,7 +1029,7 @@ class VaultCharm(CharmBase):
         vault: Vault,
         relation: Relation,
         role_name: str,
-        egress_subnet: List[str],
+        egress_subnets: List[str],
         label: str,
         secret_id: str,
     ) -> Secret:
@@ -1039,9 +1039,9 @@ class VaultCharm(CharmBase):
         credentials = secret.get_content(refresh=True)
         role_secret_id_data = vault.read_role_secret(role_name, credentials["role-secret-id"])
         # if unit subnet is already in cidr_list, skip
-        if sorted(egress_subnet) == sorted(role_secret_id_data["cidr_list"]):
+        if sorted(egress_subnets) == sorted(role_secret_id_data["cidr_list"]):
             return secret
-        credentials["role-secret-id"] = vault.generate_role_secret_id(role_name, egress_subnet)
+        credentials["role-secret-id"] = vault.generate_role_secret_id(role_name, egress_subnets)
         secret.set_content(credentials)
         return secret
 

--- a/tests/integration/vault_kv_requirer_operator/src/charm.py
+++ b/tests/integration/vault_kv_requirer_operator/src/charm.py
@@ -60,8 +60,9 @@ class VaultKVRequirerCharm(CharmBase):
         if not binding:
             logger.error("Binding not found")
             return
-        egress_subnet = [str(subnet) for subnet in binding.network.egress_subnets]
-        self.vault_kv.request_credentials(relation, egress_subnet, self.get_nonce())
+        egress_subnets = [str(subnet) for subnet in binding.network.egress_subnets]
+        egress_subnets.append(str(binding.network.interfaces[0].subnet))
+        self.vault_kv.request_credentials(relation, egress_subnets, self.get_nonce())
 
     def _on_kv_ready(self, event: VaultKvReadyEvent):
         """Store the Vault KV credentials in a secret."""

--- a/tests/integration/vault_kv_requirer_operator/src/charm.py
+++ b/tests/integration/vault_kv_requirer_operator/src/charm.py
@@ -60,7 +60,7 @@ class VaultKVRequirerCharm(CharmBase):
         if not binding:
             logger.error("Binding not found")
             return
-        egress_subnet = str(binding.network.interfaces[0].subnet)
+        egress_subnet = [str(subnet) for subnet in binding.network.egress_subnets]
         self.vault_kv.request_credentials(relation, egress_subnet, self.get_nonce())
 
     def _on_kv_ready(self, event: VaultKvReadyEvent):

--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_kv.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_kv.py
@@ -107,7 +107,7 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             remote_unit,
-            key_values={"nonce": "abcd", "egress_subnet": json.dumps(["10.0.0.1/32"])},
+            key_values={"nonce": "abcd", "egress_subnets": json.dumps(["10.0.0.1/32"])},
         )
         args, _ = _on_new_vault_kv_client_attached.call_args
         event = args[0]
@@ -213,12 +213,12 @@ class TestVaultKvProvides(unittest.TestCase):
     ):
         suffix = "dummy"
         nonce = "abcd"
-        egress_subnet = ["10.0.0.1/32"]
+        egress_subnets = ["10.0.0.1/32"]
         remote_app, remote_unit, _, rel_id = self.setup_relation()
         self.harness.update_relation_data(
             rel_id,
             remote_unit,
-            key_values={"nonce": nonce, "egress_subnet": json.dumps(egress_subnet)},
+            key_values={"nonce": nonce, "egress_subnets": json.dumps(egress_subnets)},
         )
         self.harness.update_relation_data(
             relation_id=rel_id,
@@ -234,7 +234,7 @@ class TestVaultKvProvides(unittest.TestCase):
             app_name=remote_app,
             unit_name=remote_unit,
             mount_suffix=suffix,
-            egress_subnet=egress_subnet,
+            egress_subnets=egress_subnets,
             nonce=nonce,
         )
 
@@ -244,7 +244,7 @@ class TestVaultKvProvides(unittest.TestCase):
         suffix = "dummy"
         nonce_1 = "abcd"
         nonce_2 = "efgh"
-        egress_subnet = ["10.0.0.1/32"]
+        egress_subnets = ["10.0.0.1/32"]
         remote_app, remote_unit_1, _, rel_id = self.setup_relation()
         remote_unit_2 = remote_app + "/1"
         self.harness.add_relation_unit(
@@ -254,12 +254,12 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             remote_unit_1,
-            key_values={"nonce": nonce_1, "egress_subnet": json.dumps(egress_subnet)},
+            key_values={"nonce": nonce_1, "egress_subnets": json.dumps(egress_subnets)},
         )
         self.harness.update_relation_data(
             rel_id,
             remote_unit_2,
-            key_values={"nonce": nonce_2, "egress_subnet": json.dumps(egress_subnet)},
+            key_values={"nonce": nonce_2, "egress_subnets": json.dumps(egress_subnets)},
         )
         self.harness.update_relation_data(
             relation_id=rel_id,
@@ -280,7 +280,7 @@ class TestVaultKvProvides(unittest.TestCase):
             app_name=remote_app,
             unit_name=remote_unit_2,
             mount_suffix=suffix,
-            egress_subnet=egress_subnet,
+            egress_subnets=egress_subnets,
             nonce=nonce_2,
         )
 
@@ -290,8 +290,8 @@ class TestVaultKvProvides(unittest.TestCase):
         suffix = "dummy"
         nonce_1 = "abcd"
         nonce_2 = "efgh"
-        egress_subnet_1 = ["10.0.0.1/32"]
-        egress_subnet_2 = ["10.0.0.2/32"]
+        egress_subnets_1 = ["10.0.0.1/32"]
+        egress_subnets_2 = ["10.0.0.2/32"]
         remote_app_1, remote_unit_1, _, rel_id_1 = self.setup_relation()
         remote_app_2, remote_unit_2, _, rel_id_2 = self.setup_relation(
             remote_app="vault-kv-requires-b"
@@ -299,12 +299,12 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id_1,
             remote_unit_1,
-            key_values={"nonce": nonce_1, "egress_subnet": json.dumps(egress_subnet_1)},
+            key_values={"nonce": nonce_1, "egress_subnets": json.dumps(egress_subnets_1)},
         )
         self.harness.update_relation_data(
             rel_id_2,
             remote_unit_2,
-            key_values={"nonce": nonce_2, "egress_subnet": json.dumps(egress_subnet_2)},
+            key_values={"nonce": nonce_2, "egress_subnets": json.dumps(egress_subnets_2)},
         )
         self.harness.update_relation_data(
             relation_id=rel_id_1,
@@ -330,7 +330,7 @@ class TestVaultKvProvides(unittest.TestCase):
             app_name=remote_app_2,
             unit_name=remote_unit_2,
             mount_suffix=suffix + "b",
-            egress_subnet=egress_subnet_2,
+            egress_subnets=egress_subnets_2,
             nonce=nonce_2,
         )
 
@@ -342,7 +342,7 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             remote_unit,
-            key_values={"nonce": nonce, "egress_subnet": json.dumps(["10.0.0.1/32"])},
+            key_values={"nonce": nonce, "egress_subnets": json.dumps(["10.0.0.1/32"])},
         )
         self.harness.update_relation_data(
             relation_id=rel_id,
@@ -368,7 +368,7 @@ class TestVaultKvProvides(unittest.TestCase):
         suffix = "dummy"
         nonce1 = "abcd"
         nonce2 = "efgh"
-        egress_subnet = ["10.0.0.1/32"]
+        egress_subnets = ["10.0.0.1/32"]
         remote_app, remote_unit_1, _, rel_id = self.setup_relation()
         remote_unit_2 = remote_app + "/1"
         self.harness.add_relation_unit(
@@ -378,12 +378,12 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             remote_unit_1,
-            key_values={"nonce": nonce1, "egress_subnet": json.dumps(egress_subnet)},
+            key_values={"nonce": nonce1, "egress_subnets": json.dumps(egress_subnets)},
         )
         self.harness.update_relation_data(
             rel_id,
             remote_unit_2,
-            key_values={"nonce": nonce2, "egress_subnet": json.dumps(egress_subnet)},
+            key_values={"nonce": nonce2, "egress_subnets": json.dumps(egress_subnets)},
         )
         self.harness.update_relation_data(
             relation_id=rel_id,
@@ -399,7 +399,7 @@ class TestVaultKvProvides(unittest.TestCase):
             app_name=remote_app,
             unit_name=remote_unit_1,
             mount_suffix=suffix,
-            egress_subnet=egress_subnet,
+            egress_subnets=egress_subnets,
             nonce=nonce1,
         )
         expected_kv_request_2 = KVRequest(
@@ -407,7 +407,7 @@ class TestVaultKvProvides(unittest.TestCase):
             app_name=remote_app,
             unit_name=remote_unit_2,
             mount_suffix=suffix,
-            egress_subnet=egress_subnet,
+            egress_subnets=egress_subnets,
             nonce=nonce2,
         )
         assert expected_kv_request_1 in kv_requests
@@ -488,7 +488,7 @@ class TestVaultKvRequires(unittest.TestCase):
                 "vault_url": "https://vault.example.com",
                 "ca_certificate": "ca certificate data",
                 "mount": "charm-vault-kv-requires-dummy",
-                "egress_subnet": "1.1.1.1",
+                "egress_subnets": "1.1.1.1",
                 "credentials": json.dumps({"abcd": "dummy"}),
             },
         )

--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_kv.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_kv.py
@@ -15,6 +15,7 @@ from charms.vault_k8s.v0.vault_kv import (
     VaultKvProvides,
     VaultKvReadyEvent,
     VaultKvRequires,
+    get_egress_subnets_list_from_relation_data,
 )
 from ops import testing
 from ops.charm import CharmBase
@@ -504,3 +505,14 @@ class TestVaultKvRequires(unittest.TestCase):
     ):
         self.setup_relation()
         _on_ready.assert_not_called()
+
+    def test_given_egress_subnets_in_relation_databag_when_get_egress_subnets_list_from_relation_data_then_list_is_returned(  # noqa: E501
+        self,
+    ):
+        relation_datbage_dict = {
+            "nonce": "abcd",
+            "egress_subnet": "10.0.0.1/32, 10.0.1.1/32,10.0.2.1/32",
+        }
+        assert sorted(get_egress_subnets_list_from_relation_data(relation_datbage_dict)) == sorted(
+            ["10.0.0.1/32", "10.0.1.1/32", "10.0.2.1/32"]
+        )

--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_kv.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_kv.py
@@ -107,7 +107,7 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             remote_unit,
-            key_values={"nonce": "abcd", "egress_subnets": json.dumps(["10.0.0.1/32"])},
+            key_values={"nonce": "abcd", "egress_subnet": "10.0.0.1/32"},
         )
         args, _ = _on_new_vault_kv_client_attached.call_args
         event = args[0]
@@ -218,7 +218,7 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             remote_unit,
-            key_values={"nonce": nonce, "egress_subnets": json.dumps(egress_subnets)},
+            key_values={"nonce": nonce, "egress_subnet": ",".join(egress_subnets)},
         )
         self.harness.update_relation_data(
             relation_id=rel_id,
@@ -254,12 +254,12 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             remote_unit_1,
-            key_values={"nonce": nonce_1, "egress_subnets": json.dumps(egress_subnets)},
+            key_values={"nonce": nonce_1, "egress_subnet": ",".join(egress_subnets)},
         )
         self.harness.update_relation_data(
             rel_id,
             remote_unit_2,
-            key_values={"nonce": nonce_2, "egress_subnets": json.dumps(egress_subnets)},
+            key_values={"nonce": nonce_2, "egress_subnet": ",".join(egress_subnets)},
         )
         self.harness.update_relation_data(
             relation_id=rel_id,
@@ -290,7 +290,7 @@ class TestVaultKvProvides(unittest.TestCase):
         suffix = "dummy"
         nonce_1 = "abcd"
         nonce_2 = "efgh"
-        egress_subnets_1 = ["10.0.0.1/32"]
+        egress_subnets_1 = ["10.0.0.1/32", "10.0.1.1/32"]
         egress_subnets_2 = ["10.0.0.2/32"]
         remote_app_1, remote_unit_1, _, rel_id_1 = self.setup_relation()
         remote_app_2, remote_unit_2, _, rel_id_2 = self.setup_relation(
@@ -299,12 +299,12 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id_1,
             remote_unit_1,
-            key_values={"nonce": nonce_1, "egress_subnets": json.dumps(egress_subnets_1)},
+            key_values={"nonce": nonce_1, "egress_subnet": ",".join(egress_subnets_1)},
         )
         self.harness.update_relation_data(
             rel_id_2,
             remote_unit_2,
-            key_values={"nonce": nonce_2, "egress_subnets": json.dumps(egress_subnets_2)},
+            key_values={"nonce": nonce_2, "egress_subnet": ",".join(egress_subnets_2)},
         )
         self.harness.update_relation_data(
             relation_id=rel_id_1,
@@ -342,7 +342,7 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             remote_unit,
-            key_values={"nonce": nonce, "egress_subnets": json.dumps(["10.0.0.1/32"])},
+            key_values={"nonce": nonce, "egress_subnet": "10.0.0.1/32"},
         )
         self.harness.update_relation_data(
             relation_id=rel_id,
@@ -378,12 +378,12 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             remote_unit_1,
-            key_values={"nonce": nonce1, "egress_subnets": json.dumps(egress_subnets)},
+            key_values={"nonce": nonce1, "egress_subnet": ",".join(egress_subnets)},
         )
         self.harness.update_relation_data(
             rel_id,
             remote_unit_2,
-            key_values={"nonce": nonce2, "egress_subnets": json.dumps(egress_subnets)},
+            key_values={"nonce": nonce2, "egress_subnet": ",".join(egress_subnets)},
         )
         self.harness.update_relation_data(
             relation_id=rel_id,
@@ -488,7 +488,7 @@ class TestVaultKvRequires(unittest.TestCase):
                 "vault_url": "https://vault.example.com",
                 "ca_certificate": "ca certificate data",
                 "mount": "charm-vault-kv-requires-dummy",
-                "egress_subnets": "1.1.1.1",
+                "egress_subnet": "1.1.1.1",
                 "credentials": json.dumps({"abcd": "dummy"}),
             },
         )

--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_kv.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_kv.py
@@ -107,7 +107,7 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             remote_unit,
-            key_values={"nonce": "abcd", "egress_subnet": "10.0.0.1/32"},
+            key_values={"nonce": "abcd", "egress_subnet": json.dumps(["10.0.0.1/32"])},
         )
         args, _ = _on_new_vault_kv_client_attached.call_args
         event = args[0]
@@ -213,12 +213,12 @@ class TestVaultKvProvides(unittest.TestCase):
     ):
         suffix = "dummy"
         nonce = "abcd"
-        egress_subnet = "10.0.0.1/32"
+        egress_subnet = ["10.0.0.1/32"]
         remote_app, remote_unit, _, rel_id = self.setup_relation()
         self.harness.update_relation_data(
             rel_id,
             remote_unit,
-            key_values={"nonce": nonce, "egress_subnet": egress_subnet},
+            key_values={"nonce": nonce, "egress_subnet": json.dumps(egress_subnet)},
         )
         self.harness.update_relation_data(
             relation_id=rel_id,
@@ -244,7 +244,7 @@ class TestVaultKvProvides(unittest.TestCase):
         suffix = "dummy"
         nonce_1 = "abcd"
         nonce_2 = "efgh"
-        egress_subnet = "10.0.0.1/32"
+        egress_subnet = ["10.0.0.1/32"]
         remote_app, remote_unit_1, _, rel_id = self.setup_relation()
         remote_unit_2 = remote_app + "/1"
         self.harness.add_relation_unit(
@@ -254,12 +254,12 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             remote_unit_1,
-            key_values={"nonce": nonce_1, "egress_subnet": egress_subnet},
+            key_values={"nonce": nonce_1, "egress_subnet": json.dumps(egress_subnet)},
         )
         self.harness.update_relation_data(
             rel_id,
             remote_unit_2,
-            key_values={"nonce": nonce_2, "egress_subnet": egress_subnet},
+            key_values={"nonce": nonce_2, "egress_subnet": json.dumps(egress_subnet)},
         )
         self.harness.update_relation_data(
             relation_id=rel_id,
@@ -290,8 +290,8 @@ class TestVaultKvProvides(unittest.TestCase):
         suffix = "dummy"
         nonce_1 = "abcd"
         nonce_2 = "efgh"
-        egress_subnet_1 = "10.0.0.1/32"
-        egress_subnet_2 = "10.0.0.2/32"
+        egress_subnet_1 = ["10.0.0.1/32"]
+        egress_subnet_2 = ["10.0.0.2/32"]
         remote_app_1, remote_unit_1, _, rel_id_1 = self.setup_relation()
         remote_app_2, remote_unit_2, _, rel_id_2 = self.setup_relation(
             remote_app="vault-kv-requires-b"
@@ -299,12 +299,12 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id_1,
             remote_unit_1,
-            key_values={"nonce": nonce_1, "egress_subnet": egress_subnet_1},
+            key_values={"nonce": nonce_1, "egress_subnet": json.dumps(egress_subnet_1)},
         )
         self.harness.update_relation_data(
             rel_id_2,
             remote_unit_2,
-            key_values={"nonce": nonce_2, "egress_subnet": egress_subnet_2},
+            key_values={"nonce": nonce_2, "egress_subnet": json.dumps(egress_subnet_2)},
         )
         self.harness.update_relation_data(
             relation_id=rel_id_1,
@@ -342,7 +342,7 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             remote_unit,
-            key_values={"nonce": nonce, "egress_subnet": "10.0.0.1/32"},
+            key_values={"nonce": nonce, "egress_subnet": json.dumps(["10.0.0.1/32"])},
         )
         self.harness.update_relation_data(
             relation_id=rel_id,
@@ -368,7 +368,7 @@ class TestVaultKvProvides(unittest.TestCase):
         suffix = "dummy"
         nonce1 = "abcd"
         nonce2 = "efgh"
-        egress_subnet = "10.0.0.1/32"
+        egress_subnet = ["10.0.0.1/32"]
         remote_app, remote_unit_1, _, rel_id = self.setup_relation()
         remote_unit_2 = remote_app + "/1"
         self.harness.add_relation_unit(
@@ -378,12 +378,12 @@ class TestVaultKvProvides(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             remote_unit_1,
-            key_values={"nonce": nonce1, "egress_subnet": egress_subnet},
+            key_values={"nonce": nonce1, "egress_subnet": json.dumps(egress_subnet)},
         )
         self.harness.update_relation_data(
             rel_id,
             remote_unit_2,
-            key_values={"nonce": nonce2, "egress_subnet": egress_subnet},
+            key_values={"nonce": nonce2, "egress_subnet": json.dumps(egress_subnet)},
         )
         self.harness.update_relation_data(
             relation_id=rel_id,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -200,10 +200,10 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader()
         rel_id = self.harness.add_relation(relation_name, app_name)
         unit_name = app_name + "/0"
-        egress_subnet = "10.20.20.20/32"
+        egress_subnet = ["10.20.20.20/32"]
         self.harness.add_relation_unit(rel_id, unit_name)
         self.harness.update_relation_data(
-            rel_id, unit_name, {"egress_subnet": egress_subnet, "nonce": "0"}
+            rel_id, unit_name, {"egress_subnet": json.dumps(egress_subnet), "nonce": "0"}
         )
 
         return (rel_id, egress_subnet)
@@ -1396,7 +1396,7 @@ class TestCharm(unittest.TestCase):
         event.app_name = VAULT_KV_REQUIRER_APPLICATION_NAME
         event.unit_name = f"{VAULT_KV_REQUIRER_APPLICATION_NAME}/0"
         event.mount_suffix = "suffix"
-        event.egress_subnet = "2.2.2.0/24"
+        event.egress_subnet = ["2.2.2.0/24"]
         event.nonce = "123123"
         self.harness.charm._on_new_vault_kv_client_attached(event)
         self.mock_vault.enable_secrets_engine.assert_called_once_with(
@@ -1432,7 +1432,7 @@ class TestCharm(unittest.TestCase):
         event.app_name = VAULT_KV_REQUIRER_APPLICATION_NAME
         event.unit_name = f"{VAULT_KV_REQUIRER_APPLICATION_NAME}/0"
         event.mount_suffix = "suffix"
-        event.egress_subnet = "2.2.2.0/24"
+        event.egress_subnet = ["2.2.2.0/24"]
         event.nonce = "123123"
         self.harness.charm._on_new_vault_kv_client_attached(event)
         set_vault_url.assert_called()
@@ -1458,7 +1458,7 @@ class TestCharm(unittest.TestCase):
             secret_id="whatever secret id",
         )
         rel_id, egress_subnet = self.setup_vault_kv_relation()
-        self.mock_vault.read_role_secret.return_value = {"cidr_list": [egress_subnet]}
+        self.mock_vault.read_role_secret.return_value = {"cidr_list": egress_subnet}
 
         mount_suffix = "whatever-suffix"
         self.harness.update_relation_data(
@@ -1468,7 +1468,7 @@ class TestCharm(unittest.TestCase):
 
         with patch("ops.Secret.set_content") as set_content:
             self.harness.update_relation_data(
-                rel_id, unit_name, {"egress_subnet": "10.20.20.240/32"}
+                rel_id, unit_name, {"egress_subnet": json.dumps(["10.20.20.240/32"])}
             )
             assert set_content.call_count == 1
 
@@ -1499,7 +1499,7 @@ class TestCharm(unittest.TestCase):
         event.app_name = VAULT_KV_REQUIRER_APPLICATION_NAME
         event.unit_name = f"{VAULT_KV_REQUIRER_APPLICATION_NAME}/0"
         event.mount_suffix = "suffix"
-        event.egress_subnet = "2.2.2.0/24"
+        event.egress_subnet = ["2.2.2.0/24"]
         event.nonce = "123123"
         self.harness.charm._on_new_vault_kv_client_attached(event)
         self.mock_vault.enable_secrets_engine.assert_called_with(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -203,7 +203,7 @@ class TestCharm(unittest.TestCase):
         egress_subnets = ["10.20.20.20/32"]
         self.harness.add_relation_unit(rel_id, unit_name)
         self.harness.update_relation_data(
-            rel_id, unit_name, {"egress_subnets": json.dumps(egress_subnets), "nonce": "0"}
+            rel_id, unit_name, {"egress_subnet": ",".join(egress_subnets), "nonce": "0"}
         )
 
         return (rel_id, egress_subnets)
@@ -1468,7 +1468,7 @@ class TestCharm(unittest.TestCase):
 
         with patch("ops.Secret.set_content") as set_content:
             self.harness.update_relation_data(
-                rel_id, unit_name, {"egress_subnets": json.dumps(["10.20.20.240/32"])}
+                rel_id, unit_name, {"egress_subnet": "10.20.20.240/32"}
             )
             assert set_content.call_count == 1
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -200,13 +200,13 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader()
         rel_id = self.harness.add_relation(relation_name, app_name)
         unit_name = app_name + "/0"
-        egress_subnet = ["10.20.20.20/32"]
+        egress_subnets = ["10.20.20.20/32"]
         self.harness.add_relation_unit(rel_id, unit_name)
         self.harness.update_relation_data(
-            rel_id, unit_name, {"egress_subnet": json.dumps(egress_subnet), "nonce": "0"}
+            rel_id, unit_name, {"egress_subnets": json.dumps(egress_subnets), "nonce": "0"}
         )
 
-        return (rel_id, egress_subnet)
+        return (rel_id, egress_subnets)
 
     # Test install
     @patch("ops.model.Container.remove_path")
@@ -1396,7 +1396,7 @@ class TestCharm(unittest.TestCase):
         event.app_name = VAULT_KV_REQUIRER_APPLICATION_NAME
         event.unit_name = f"{VAULT_KV_REQUIRER_APPLICATION_NAME}/0"
         event.mount_suffix = "suffix"
-        event.egress_subnet = ["2.2.2.0/24"]
+        event.egress_subnets = ["2.2.2.0/24"]
         event.nonce = "123123"
         self.harness.charm._on_new_vault_kv_client_attached(event)
         self.mock_vault.enable_secrets_engine.assert_called_once_with(
@@ -1432,7 +1432,7 @@ class TestCharm(unittest.TestCase):
         event.app_name = VAULT_KV_REQUIRER_APPLICATION_NAME
         event.unit_name = f"{VAULT_KV_REQUIRER_APPLICATION_NAME}/0"
         event.mount_suffix = "suffix"
-        event.egress_subnet = ["2.2.2.0/24"]
+        event.egress_subnets = ["2.2.2.0/24"]
         event.nonce = "123123"
         self.harness.charm._on_new_vault_kv_client_attached(event)
         set_vault_url.assert_called()
@@ -1457,8 +1457,8 @@ class TestCharm(unittest.TestCase):
             role_id="root token content",
             secret_id="whatever secret id",
         )
-        rel_id, egress_subnet = self.setup_vault_kv_relation()
-        self.mock_vault.read_role_secret.return_value = {"cidr_list": egress_subnet}
+        rel_id, egress_subnets = self.setup_vault_kv_relation()
+        self.mock_vault.read_role_secret.return_value = {"cidr_list": egress_subnets}
 
         mount_suffix = "whatever-suffix"
         self.harness.update_relation_data(
@@ -1468,7 +1468,7 @@ class TestCharm(unittest.TestCase):
 
         with patch("ops.Secret.set_content") as set_content:
             self.harness.update_relation_data(
-                rel_id, unit_name, {"egress_subnet": json.dumps(["10.20.20.240/32"])}
+                rel_id, unit_name, {"egress_subnets": json.dumps(["10.20.20.240/32"])}
             )
             assert set_content.call_count == 1
 
@@ -1499,7 +1499,7 @@ class TestCharm(unittest.TestCase):
         event.app_name = VAULT_KV_REQUIRER_APPLICATION_NAME
         event.unit_name = f"{VAULT_KV_REQUIRER_APPLICATION_NAME}/0"
         event.mount_suffix = "suffix"
-        event.egress_subnet = ["2.2.2.0/24"]
+        event.egress_subnets = ["2.2.2.0/24"]
         event.nonce = "123123"
         self.harness.charm._on_new_vault_kv_client_attached(event)
         self.mock_vault.enable_secrets_engine.assert_called_with(


### PR DESCRIPTION
# Description

**Note**: This is a breaking change on the provider side, but since this is handled in the same PR in Vault I think it should be okay. No breaking changes on the requirer side by allowing it to set the egress subnet as string or as list.

Instead of using the `interfaces` of the network binding to configure the approle in vault we use the list of `egress_subnets`.
Juju describes the interfaces as:
```
A list of network interface details. This includes the information
    about how the application should be configured (for example, what IP
    addresses should be bound to).
```

While it describes the `egress_subnets` to be:
```
A list of networks representing the subnets that other units will see
    the charm connecting from. Due to things like NAT it isn't always possible to
    narrow it down to a single address, but when it is clear, the CIDRs will
    be constrained to a single address (for example, 10.0.0.1/32).
```

A solution as simple as changing the example docstring in the lib to `str(self.model.get_binding(relation).network.egress_subnets][0].subnet)` could have been enough, however this solution that introduces lists is based on the `Due to things like NAT it isn't always possible to
    narrow it down to a single address, but when it is clear, the CIDRs will
    be constrained to a single address (for example, 10.0.0.1/32)` part of the documentation of the `egress_subnets` 

This change will allow the charm to respect the `--via` option when related in juju, this is important when Vault is related to a kv requirer that is deployed in a different model.

Fixes https://github.com/canonical/vault-operator/issues/244
# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
