### PR TITLE
fix: Removes the vault-kv secret when the unit is removed

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/lib/charms/vault_k8s/v0/vault_kv.py
@@ -135,7 +135,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -1012,6 +1012,9 @@ class VaultCharm(CharmBase):
         Fetch secret id from peer relation, if it exists, update the secret,
         otherwise create it.
         """
+        # TODO bug: https://bugs.launchpad.net/juju/+bug/2075153
+        # Until the referenced bug is fixed we must pass the secret ID here
+        # not to lose the secret://modeluuid:secretID format
         current_credentials = self.vault_kv.get_credentials(relation)
         secret_id = current_credentials.get(nonce, None)
         if secret_id is None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -477,10 +477,6 @@ class VaultCharm(CharmBase):
         label = self._get_vault_kv_secret_label(unit_name=event.unit_name)
         self._remove_juju_secret_by_label(label=label)
 
-    def _get_vault_kv_secret_label(self, unit_name: str):
-        unit_name_dash = unit_name.replace("/", "-")
-        return f"{KV_SECRET_PREFIX}{unit_name_dash}"
-
     def _configure_pki_secrets_engine(self) -> None:
         """Configure the PKI secrets engine."""
         if not self.unit.is_leader():
@@ -1307,6 +1303,10 @@ class VaultCharm(CharmBase):
             juju_secret.remove_all_revisions()
         except SecretNotFoundError:
             return
+
+    def _get_vault_kv_secret_label(self, unit_name: str):
+        unit_name_dash = unit_name.replace("/", "-")
+        return f"{KV_SECRET_PREFIX}{unit_name_dash}"
 
     def _get_missing_s3_parameters(self) -> List[str]:
         """Return the list of missing S3 parameters.


### PR DESCRIPTION
# Description

This PR introduces some changes and refactors the code to ensure:
- Vault KV secrets of a specific unit are removed when the unit relation departs
- Secret ID is used to get the secret as a workaround to the issues reported [here](https://bugs.launchpad.net/juju/+bug/2075153) and [here](https://github.com/canonical/operator/issues/1312).
- Adds the `VaultKvClientDetachedEvent` custom event that wraps the relation departed event.
- Adds unit tests.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
