### PR TITLE
refactor: replace harness with scenario for unit testing (vault-kv)

### DIFF
--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_kv.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_kv.py
@@ -63,6 +63,7 @@ class VaultKvProviderCharm(CharmBase):
             relation_name=VAULT_KV_RELATION_NAME,
             relation_id=int(relation_id),
         )
+        assert relation
         self.interface.set_vault_url(relation, url)
 
     def _on_set_mount_action(self, event: ActionEvent):
@@ -72,6 +73,7 @@ class VaultKvProviderCharm(CharmBase):
             relation_name=VAULT_KV_RELATION_NAME,
             relation_id=int(relation_id),
         )
+        assert relation
         self.interface.set_mount(relation, mount)
 
     def _on_set_unit_credentials_action(self, event: ActionEvent):
@@ -82,6 +84,7 @@ class VaultKvProviderCharm(CharmBase):
             relation_name=VAULT_KV_RELATION_NAME,
             relation_id=int(relation_id),
         )
+        assert relation
         secret = self.model.get_secret(id=secret_id)
         self.interface.set_unit_credentials(relation=relation, nonce=nonce, secret=secret)
 
@@ -608,6 +611,7 @@ class TestVaultKvProvides(unittest.TestCase):
         action_output = self.ctx.run_action(action, state_in)
 
         assert action_output.success is True
+        assert action_output.results
         assert {
             "relation_id": vault_kv_relation.relation_id,
             "app_name": vault_kv_relation.remote_app_name,


### PR DESCRIPTION
# Description

Replace harness with scenario for unit testing. The change was already done for the `vault TLS` library. Here we do it for `vault-kv` and follow-up PR's will take care of it for the remaining test files. 

## Rationale

The scenario framework enforces our current approach with:
- Arrange (state in)
- Act (juju event)
- Assert (state out)

This makes tests easier to read, to write, and to parameterise .

## Reference
- https://github.com/canonical/ops-scenario

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
