### PR TITLE
refactor: Replace optional with newer syntax

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_autounseal.py
+++ b/lib/charms/vault_k8s/v0/vault_autounseal.py
@@ -64,7 +64,7 @@ where `vault a` is the Vault app which will provide the autounseal service, and
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import ops
 from interface_tester import DataBagSchema
@@ -346,7 +346,7 @@ class VaultAutounsealProvides(ops.Object):
             }
         )
 
-    def get_outstanding_requests(self, relation_id: Optional[int] = None) -> List[Relation]:
+    def get_outstanding_requests(self, relation_id: int | None = None) -> List[Relation]:
         """Get the outstanding requests for the relation.
 
         This will retrieve any vault-autounseal relations that have not yet had
@@ -359,7 +359,7 @@ class VaultAutounsealProvides(ops.Object):
                 outstanding_requests.append(relation)
         return outstanding_requests
 
-    def get_active_relations(self, relation_id: Optional[int] = None) -> List[Relation]:
+    def get_active_relations(self, relation_id: int | None = None) -> List[Relation]:
         """Get all active relations on the relation name this class was initialized with.
 
         Args:
@@ -379,14 +379,14 @@ class VaultAutounsealProvides(ops.Object):
         )
         return [relation for relation in relations if relation.active]
 
-    def _credentials_issued_for_request(self, relation_id: Optional[int]) -> bool:
+    def _credentials_issued_for_request(self, relation_id: int | None) -> bool:
         relation = self.model.get_relation(self.relation_name, relation_id)
         if not relation:
             return False
         credentials = self._get_credentials(relation)
         return credentials is not None
 
-    def _get_credentials(self, relation: ops.Relation) -> Optional[ApproleDetails]:
+    def _get_credentials(self, relation: ops.Relation) -> ApproleDetails | None:
         """Retrieve the credentials from the Juju secret.
 
         Args:
@@ -449,7 +449,7 @@ class VaultAutounsealRequires(ops.Object):
     def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
         self.on.vault_autounseal_provider_relation_broken.emit()
 
-    def get_details(self) -> Optional[AutounsealDetails]:
+    def get_details(self) -> AutounsealDetails | None:
         """Return the vault address, role id, secret id and ca certificate from the relation databag.
 
         Returns:
@@ -480,7 +480,7 @@ class VaultAutounsealRequires(ops.Object):
             ca_certificate,
         )
 
-    def _get_credentials(self, relation: ops.Relation) -> Optional[ApproleDetails]:
+    def _get_credentials(self, relation: ops.Relation) -> ApproleDetails | None:
         """Return the token from the Juju secret.
 
         Returns:
@@ -499,7 +499,7 @@ class VaultAutounsealRequires(ops.Object):
         return _get_credentials_from_secret(secret)
 
 
-def _get_credentials_from_secret(secret: ops.Secret) -> Optional[ApproleDetails]:
+def _get_credentials_from_secret(secret: ops.Secret) -> ApproleDetails | None:
     """Retrieve the Approle credentials from the Juju secret.
 
     Args:

--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -11,7 +11,7 @@ import logging
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List, Optional, Protocol
+from typing import Dict, List, Protocol
 
 import hvac
 import requests
@@ -115,7 +115,7 @@ class VaultClientError(Exception):
 class Vault:
     """Class to interact with Vault through its API."""
 
-    def __init__(self, url: str, ca_cert_path: Optional[str]):
+    def __init__(self, url: str, ca_cert_path: str | None):
         self._client = hvac.Client(url=url, verify=ca_cert_path if ca_cert_path else False)
 
     def authenticate(self, auth_details: AuthMethod) -> bool:
@@ -132,7 +132,7 @@ class Vault:
             return False
         return True
 
-    def get_token_data(self) -> Optional[Dict]:
+    def get_token_data(self) -> Dict | None:
         """Check if given token is accepted by vault, and returns the token data if so."""
         try:
             token_data = self._client.auth.token.lookup_self()["data"]
@@ -277,8 +277,8 @@ class Vault:
         role_name: str,
         token_ttl=None,
         token_max_ttl=None,
-        policies: Optional[List[str]] = None,
-        cidrs: Optional[List[str]] = None,
+        policies: List[str] | None = None,
+        cidrs: List[str] | None = None,
         token_period=None,
     ) -> str:
         """Create/update a role within vault associating the supplied policies.
@@ -303,7 +303,7 @@ class Vault:
         response = self._client.auth.approle.read_role_id(role_name)
         return response["data"]["role_id"]
 
-    def generate_role_secret_id(self, name: str, cidrs: Optional[List[str]] = None) -> str:
+    def generate_role_secret_id(self, name: str, cidrs: List[str] | None = None) -> str:
         """Generate a new secret tied to an AppRole."""
         response = self._client.auth.approle.generate_secret_id(name, cidr_list=cidrs)
         return response["data"]["secret_id"]
@@ -380,7 +380,7 @@ class Vault:
         role: str,
         csr: str,
         common_name: str,
-    ) -> Optional[Certificate]:
+    ) -> Certificate | None:
         """Sign a certificate signing request for the PKI backend.
 
         Args:

--- a/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/lib/charms/vault_k8s/v0/vault_kv.py
@@ -121,7 +121,7 @@ import json
 import logging
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List
 
 import ops
 from interface_tester.schema_base import DataBagSchema  # type: ignore[import-untyped]
@@ -434,7 +434,7 @@ class VaultKvProvides(ops.Object):
         credentials[nonce] = secret.id
         relation.data[self.charm.app]["credentials"] = json.dumps(credentials, sort_keys=True)
 
-    def remove_unit_credentials(self, relation: ops.Relation, nonce: Union[str, Iterable[str]]):
+    def remove_unit_credentials(self, relation: ops.Relation, nonce: str | Iterable[str]):
         """Remove nonce(s) from the relation."""
         if not self.charm.unit.is_leader():
             return
@@ -453,7 +453,7 @@ class VaultKvProvides(ops.Object):
         """Get the unit credentials from the relation."""
         return json.loads(relation.data[self.charm.app].get("credentials", "{}"))
 
-    def get_outstanding_kv_requests(self, relation_id: Optional[int] = None) -> List[KVRequest]:
+    def get_outstanding_kv_requests(self, relation_id: int | None = None) -> List[KVRequest]:
         """Get the outstanding requests for the relation."""
         outstanding_requests: List[KVRequest] = []
         kv_requests = self.get_kv_requests(relation_id=relation_id)
@@ -464,7 +464,7 @@ class VaultKvProvides(ops.Object):
                 outstanding_requests.append(request)
         return outstanding_requests
 
-    def get_kv_requests(self, relation_id: Optional[int] = None) -> List[KVRequest]:
+    def get_kv_requests(self, relation_id: int | None = None) -> List[KVRequest]:
         """Get all KV requests for the relation."""
         kv_requests: List[KVRequest] = []
         relations = (
@@ -497,7 +497,7 @@ class VaultKvProvides(ops.Object):
                 )
         return kv_requests
 
-    def _credentials_issued_for_request(self, nonce: str, relation_id: Optional[int]) -> bool:
+    def _credentials_issued_for_request(self, nonce: str, relation_id: int | None) -> bool:
         """Return whether credentials have been issued for the request."""
         relation = self.model.get_relation(self.relation_name, relation_id)
         if not relation:
@@ -644,7 +644,7 @@ class VaultKvRequires(ops.Object):
         self.on.gone_away.emit()
 
     def request_credentials(
-        self, relation: ops.Relation, egress_subnet: Union[List[str], str], nonce: str
+        self, relation: ops.Relation, egress_subnet: List[str] | str, nonce: str
     ) -> None:
         """Request credentials from the vault-kv relation.
 
@@ -659,25 +659,19 @@ class VaultKvRequires(ops.Object):
         self._set_unit_egress_subnets(relation, egress_subnet)
         self._set_unit_nonce(relation, nonce)
 
-    def get_vault_url(self, relation: ops.Relation) -> Optional[str]:
+    def get_vault_url(self, relation: ops.Relation) -> str | None:
         """Return the vault_url from the relation."""
-        if relation.app is None:
-            return None
         return relation.data[relation.app].get("vault_url")
 
-    def get_ca_certificate(self, relation: ops.Relation) -> Optional[str]:
+    def get_ca_certificate(self, relation: ops.Relation) -> str | None:
         """Return the ca_certificate from the relation."""
-        if relation.app is None:
-            return None
         return relation.data[relation.app].get("ca_certificate")
 
-    def get_mount(self, relation: ops.Relation) -> Optional[str]:
+    def get_mount(self, relation: ops.Relation) -> str | None:
         """Return the mount from the relation."""
-        if relation.app is None:
-            return None
         return relation.data[relation.app].get("mount")
 
-    def get_unit_credentials(self, relation: ops.Relation) -> Optional[str]:
+    def get_unit_credentials(self, relation: ops.Relation) -> str | None:
         """Return the unit credentials from the relation.
 
         Unit credentials are stored in the relation data as a Juju secret id.

--- a/lib/charms/vault_k8s/v0/vault_s3.py
+++ b/lib/charms/vault_k8s/v0/vault_s3.py
@@ -15,7 +15,7 @@ Add the following dependencies to the charm's requirements.txt file:
 """
 
 import logging
-from typing import IO, List, Optional, cast
+from typing import IO, List, cast
 
 import boto3
 from botocore.config import Config
@@ -65,7 +65,7 @@ class S3:
         access_key: str,
         secret_key: str,
         endpoint: str,
-        region: Optional[str] = AWS_DEFAULT_REGION,
+        region: str | None = AWS_DEFAULT_REGION,
     ):
         self.access_key = access_key
         self.secret_key = secret_key
@@ -185,7 +185,7 @@ class S3:
             logger.error("Error getting objects list from bucket %s: %s", bucket_name, e)
             raise S3Error(f"Error getting objects list from bucket {bucket_name}: {e}")
 
-    def get_content(self, bucket_name: str, object_key: str) -> Optional[StreamingBody]:
+    def get_content(self, bucket_name: str, object_key: str) -> StreamingBody | None:
         """Get object content from S3 bucket by key.
 
         Args:
@@ -193,7 +193,7 @@ class S3:
             object_key: S3 object key.
 
         Returns:
-            Optional[StreamingBody]: File like object with the content of the S3 object.
+            File like object with the content of the S3 object, or None if the object does not exist.
         """
         bucket = self.s3.Bucket(bucket_name)
         try:

--- a/lib/charms/vault_k8s/v0/vault_tls.py
+++ b/lib/charms/vault_k8s/v0/vault_tls.py
@@ -358,7 +358,7 @@ class VaultTLSManager(Object):
         """Get the vault CA certificate secret.
 
         Returns:
-            Tuple[Optional[str], Optional[str]]: The CA private key and certificate
+            The CA private key and certificate as a tuple
         """
         juju_secret = self.charm.model.get_secret(label=CA_CERTIFICATE_JUJU_SECRET_LABEL)
         content = juju_secret.get_content(refresh=True)
@@ -369,12 +369,6 @@ class VaultTLSManager(Object):
         private_key: str,
         certificate: str,
     ) -> None:
-        """Set the vault CA certificate secret.
-
-        Args:
-            private_key: Private key
-            certificate: certificate
-        """
         juju_secret_content = {
             "privatekey": private_key,
             "certificate": certificate,

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,7 +12,7 @@ import json
 import logging
 import socket
 from dataclasses import dataclass
-from typing import IO, Dict, List, Optional, Tuple, cast
+from typing import IO, Dict, List, Tuple, cast
 
 import hcl
 from botocore.response import StreamingBody
@@ -368,7 +368,7 @@ class VaultCharm(CharmBase):
             event.add_status(WaitingStatus("Waiting for vault to finish raft leader election"))
         event.add_status(ActiveStatus())
 
-    def _configure(self, event: Optional[ConfigChangedEvent] = None) -> None:  # noqa: C901
+    def _configure(self, event: ConfigChangedEvent | None = None) -> None:  # noqa: C901
         """Handle config-changed event.
 
         Configures pebble layer, sets the unit address in the peer relation, starts the vault
@@ -524,7 +524,7 @@ class VaultCharm(CharmBase):
         intermediate_ca_common_name = get_common_name_from_certificate(intermediate_ca)
         return intermediate_ca_common_name == common_name
 
-    def _get_pki_intermediate_ca_csr(self) -> Optional[str]:
+    def _get_pki_intermediate_ca_csr(self) -> str | None:
         """Get the current CSR from the relation data."""
         csrs = self.tls_certificates_pki.get_requirer_csrs()
         if not csrs:
@@ -651,7 +651,7 @@ class VaultCharm(CharmBase):
         self._set_kv_relation_data(relation, mount, ca_certificate, egress_subnets)
         self._remove_stale_nonce(relation=relation, nonce=nonce)
 
-    def _get_pki_ca_certificate(self) -> Optional[str]:
+    def _get_pki_ca_certificate(self) -> str | None:
         """Return the PKI CA certificate provided by the TLS provider.
 
         Validate that the CSR matches the one in secrets.
@@ -924,7 +924,7 @@ class VaultCharm(CharmBase):
                 s3_parameters[key] = value.strip()
         return s3_parameters
 
-    def _check_s3_pre_requisites(self) -> Optional[str]:
+    def _check_s3_pre_requisites(self) -> str | None:
         """Check if the S3 pre-requisites are met."""
         if not self.unit.is_leader():
             return "Only leader unit can perform backup operations"
@@ -1099,7 +1099,7 @@ class VaultCharm(CharmBase):
         except ModelError:
             return False
 
-    def _get_relation_api_address(self, relation: Relation) -> Optional[str]:
+    def _get_relation_api_address(self, relation: Relation) -> str | None:
         """Fetch the api address from relation and returns it.
 
         Example: "https://10.152.183.20:8200"
@@ -1125,7 +1125,7 @@ class VaultCharm(CharmBase):
         """
         return f"https://{socket.getfqdn()}:{self.VAULT_CLUSTER_PORT}"
 
-    def _get_autounseal_configuration(self) -> Optional[AutounsealConfigurationDetails]:
+    def _get_autounseal_configuration(self) -> AutounsealConfigurationDetails | None:
         """Retrieve the autounseal configuration details, if available.
 
         Returns the autounseal configuration details if all the required
@@ -1171,7 +1171,7 @@ class VaultCharm(CharmBase):
             self._set_juju_secret(AUTOUNSEAL_TOKEN_SECRET_LABEL, {"token": vault.token})
         return vault.token
 
-    def _get_juju_secret_content(self, label: str) -> Optional[Dict[str, str]]:
+    def _get_juju_secret_content(self, label: str) -> Dict[str, str] | None:
         """Retrieve the latest revision of the secret content from Juju.
 
         Args:
@@ -1190,7 +1190,7 @@ class VaultCharm(CharmBase):
             logger.warning("Failed to retrieve secret `%s`: %s", label, e)
             return None
 
-    def _get_juju_secret_field(self, label: str, field: str) -> Optional[str]:
+    def _get_juju_secret_field(self, label: str, field: str) -> str | None:
         """Retrieve the latest revision of the secret content from Juju.
 
         Args:
@@ -1227,7 +1227,7 @@ class VaultCharm(CharmBase):
         )
 
     def _set_juju_secret(
-        self, label: str, content: Dict[str, str], description: Optional[str] = None
+        self, label: str, content: Dict[str, str], description: str | None = None
     ) -> None:
         """Set the secret content at `label`, overwrite if it already exists.
 
@@ -1288,11 +1288,11 @@ class VaultCharm(CharmBase):
         self._container.push(path=VAULT_CONFIG_FILE_PATH, source=content)
         logger.info("Pushed %s config file", VAULT_CONFIG_FILE_PATH)
 
-    def _get_approle_auth_secret(self) -> Tuple[Optional[str], Optional[str]]:
+    def _get_approle_auth_secret(self) -> Tuple[str | None, str | None]:
         """Get the vault approle login details secret.
 
         Returns:
-            Tuple[Optional[str], Optional[List[str]]]: The root token and unseal keys.
+            The root token and unseal keys.
         """
         role_id, secret_id = self._get_juju_secret_fields(
             VAULT_CHARM_APPROLE_SECRET_LABEL, "role-id", "secret-id"
@@ -1355,11 +1355,12 @@ class VaultCharm(CharmBase):
             return False
         return False
 
-    def _create_raft_snapshot(self) -> Optional[IO[bytes]]:
+    def _create_raft_snapshot(self) -> IO[bytes] | None:
         """Create a snapshot of Vault.
 
         Returns:
-            IO[bytes]: The snapshot content as a file like object.
+            The snapshot content as a file like object, or None if the snapshot
+            could not be created.
         """
         if not (vault := self._get_active_vault_client()):
             logger.error("Failed to get Vault client, cannot create snapshot.")
@@ -1402,7 +1403,7 @@ class VaultCharm(CharmBase):
 
         return True
 
-    def _get_active_vault_client(self) -> Optional[Vault]:
+    def _get_active_vault_client(self) -> Vault | None:
         """Return an initialized vault client.
 
         Returns:
@@ -1432,7 +1433,7 @@ class VaultCharm(CharmBase):
         return vault
 
     @property
-    def _bind_address(self) -> Optional[str]:
+    def _bind_address(self) -> str | None:
         """Fetch the bind address from peer relation and returns it.
 
         Returns:
@@ -1450,7 +1451,7 @@ class VaultCharm(CharmBase):
             return None
 
     @property
-    def _ingress_address(self) -> Optional[str]:
+    def _ingress_address(self) -> str | None:
         """Fetch the ingress address from peer relation and returns it.
 
         Returns:
@@ -1525,7 +1526,7 @@ def _render_vault_config_file(
     raft_storage_path: str,
     node_id: str,
     retry_joins: List[Dict[str, str]],
-    autounseal_details: Optional[AutounsealConfigurationDetails] = None,
+    autounseal_details: AutounsealConfigurationDetails | None = None,
 ) -> str:
     jinja2_environment = Environment(loader=FileSystemLoader(CONFIG_TEMPLATE_DIR_PATH))
     template = jinja2_environment.get_template(CONFIG_TEMPLATE_NAME)

--- a/tests/integration/vault_kv_requirer_operator/src/charm.py
+++ b/tests/integration/vault_kv_requirer_operator/src/charm.py
@@ -5,7 +5,6 @@
 import logging
 import secrets
 from pathlib import Path
-from typing import Optional
 
 from charms.vault_k8s.v0.vault_kv import (
     VaultKvConnectedEvent,
@@ -162,7 +161,7 @@ class VaultKVRequirerCharm(CharmBase):
         secret = self.model.get_secret(label=NONCE_SECRET_LABEL)
         return secret.get_content(refresh=True)["nonce"]
 
-    def _get_ca_cert_location_in_charm(self) -> Optional[Path]:
+    def _get_ca_cert_location_in_charm(self) -> Path | None:
         """Return the CA certificate location in the charm (not in the workload).
 
         This path would typically be: /var/lib/juju/storage/certs/0/ca.pem


### PR DESCRIPTION
- `Optional` was a poor choice of words. It doesn't fit well in all contexts and it conflicts with the already established meaning of an optional argument (you can have an optional argument that isn't optional).
- `Optional` also makes a lot less sense from an English perspective when it's a return value.
- It's easier to read (subjective)
- It's the new way, and new things are _always_ better,
- Also removes use of `Union`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
