### PR TITLE
fix: read local app data and use scenario for unit tests (vault autounseal)

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_autounseal.py
+++ b/lib/charms/vault_k8s/v0/vault_autounseal.py
@@ -401,7 +401,7 @@ class VaultAutounsealProvides(ops.Object):
         if relation.app is None:
             logger.warning("No remote application yet")
             return None
-        credentials_secret_id = relation.data[relation.app].get("credentials_secret_id")
+        credentials_secret_id = relation.data[self.charm.app].get("credentials_secret_id")
         if credentials_secret_id is None:
             return None
         secret = self.model.get_secret(id=credentials_secret_id)


### PR DESCRIPTION
# Description

Replace unit tests from harness to scenario for the Vault autounseal integration.

Doing so I identified the problem causing infinite credentials Juju secrets being created. The Vault autounseal provider charm would look at the remote application's databag for the `credentials_secret_id` field and if the field wasn't there it would create a Juju secret. This condition was always true since the `credentials_secret_id` is in the local application databag, not the remote one. 

Fixes #457 

## Rationale (for using Scenario)

The scenario framework enforces our current approach with:
- Arrange (state in)
- Act (juju event)
- Assert (state out)

This makes tests easier to read, to write, and to parameterise .

## Reference
- https://github.com/canonical/ops-scenario

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
