### PR TITLE
build: Ignore the new grafana logql linter rules

### DIFF
--- a/grafana.lint
+++ b/grafana.lint
@@ -1,2 +1,5 @@
 exclusions:
   template-datasource-rule:
+
+  target-logql-rule:
+  target-logql-auto-rule:


### PR DESCRIPTION
I wasn't able to figure out why these lint rules were failing. I tried a few different things but my grafana knowledge is limited.

For now, we ignore the rules to get the build running again.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
