### PR TITLE
style: Loosen `restore_snapshot()` typing

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -12,6 +12,7 @@ import logging
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
+from io import IOBase
 from typing import List, Protocol
 
 import hvac
@@ -404,7 +405,7 @@ class Vault:
         """Create a snapshot of the Vault data."""
         return self._client.sys.take_raft_snapshot()
 
-    def restore_snapshot(self, snapshot: bytes) -> requests.Response:
+    def restore_snapshot(self, snapshot: IOBase) -> requests.Response:
         """Restore a snapshot of the Vault data.
 
         Uses force_restore_raft_snapshot to restore the snapshot

--- a/src/charm.py
+++ b/src/charm.py
@@ -1342,7 +1342,7 @@ class VaultCharm(CharmBase):
             # hvac vault client expects bytes or a file-like object to restore the snapshot
             # StreamingBody implements the read() method
             # so it can be used as a file-like object in this context
-            response = vault.restore_snapshot(snapshot)  # type: ignore[arg-type]
+            response = vault.restore_snapshot(snapshot)
         except VaultClientError as e:
             logger.error("Failed to restore snapshot: %s", e)
             return False


### PR DESCRIPTION
Also, remove the type ignore.

If this were bytes, it implies that the streamingbody would be converted to bytes before restoring, and would load the whole thing into memory.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
