### PR TITLE
fix: Makes sure there always is an active issuer in Vault PKI

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -383,7 +383,7 @@ class Vault:
     def create_or_update_pki_charm_role(
         self, role: str, allowed_domains: str, max_ttl: str, mount: str
     ) -> None:
-        """Create a role for the PKI backend.
+        """Create a role for the PKI backend or update it if it already exists.
 
         Args:
             role: The name of the role to create or update.
@@ -403,7 +403,7 @@ class Vault:
                 "max_ttl": max_ttl,
             },
         )
-        logger.info("Created a role for the PKI backend")
+        logger.info("Created or updated PKI role %s", role)
 
     def is_pki_role_created(self, role: str, mount: str) -> bool:
         """Check if the role is created for the PKI backend."""
@@ -488,7 +488,7 @@ class Vault:
             return (
                 self._client.secrets.pki.read_role(name=role, mount_point=mount)
                 .get("data", {})
-                .get("max_ttl", [])
+                .get("max_ttl")
             )
         except InvalidPath:
             logger.warning("Role does not exist on the specified path.")

--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -352,6 +352,7 @@ class Vault:
         role: str,
         csr: str,
         common_name: str,
+        ttl: str,
     ) -> Certificate | None:
         """Sign a certificate signing request for the PKI backend.
 
@@ -360,6 +361,9 @@ class Vault:
             role: The role to use for signing the certificate.
             csr: The certificate signing request.
             common_name: The common name for the certificate.
+            ttl: The relative validity for the certificate.
+                Should be a string in the format of a number with a unit such as
+                "120m", "10h" or "90d".
 
         Returns:
             Certificate: The signed certificate object
@@ -370,6 +374,7 @@ class Vault:
                 mount_point=mount,
                 common_name=common_name,
                 name=role,
+                extra_params={"ttl": ttl},
             )
             logger.info("Signed a PKI certificate for %s", common_name)
             return Certificate(

--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -389,7 +389,7 @@ class Vault:
             role: The name of the role to create or update.
             allowed_domains: The list of allowed domains for the role.
             max_ttl: The maximum TTL for the role.
-                Will be used as validity for the certificates issued by this role.
+                It is also used by Vault as a maximum validity for the certificates issued by this role.
                 Should be a string in the format of a number with a unit such as
                 "120m", "10h" or "90d".
             mount: The mount point of the PKI backend for which the role will be created.
@@ -483,7 +483,7 @@ class Vault:
             return False
 
     def get_role_max_ttl(self, role: str, mount: str) -> Optional[int]:
-        """Get the max ttl for the specified PKI role."""
+        """Get the max ttl for the specified PKI role in seconds."""
         try:
             return (
                 self._client.secrets.pki.read_role(name=role, mount_point=mount)

--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -12,7 +12,7 @@ import logging
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Protocol
+from typing import List, Optional, Protocol
 
 import hvac
 import requests
@@ -482,7 +482,7 @@ class Vault:
             logger.warning("Role does not exist on the specified path.")
             return False
 
-    def get_role_max_ttl(self, role: str, mount: str) -> str:
+    def get_role_max_ttl(self, role: str, mount: str) -> Optional[int]:
         """Get the max ttl for the specified PKI role."""
         try:
             return (
@@ -492,7 +492,7 @@ class Vault:
             )
         except InvalidPath:
             logger.warning("Role does not exist on the specified path.")
-            return ""
+            return None
 
     def make_latest_pki_issuer_default(self, mount: str) -> None:
         """Update the issuers config to always make the latest issuer created default issuer."""

--- a/lib/charms/vault_k8s/v0/vault_tls.py
+++ b/lib/charms/vault_k8s/v0/vault_tls.py
@@ -6,6 +6,7 @@
 import logging
 import os
 from abc import ABC, abstractmethod
+from datetime import timedelta
 from enum import Enum, auto
 from typing import FrozenSet, List, TextIO, Tuple
 
@@ -470,7 +471,7 @@ def generate_vault_ca_certificate() -> Tuple[str, str]:
     ca_certificate = generate_ca(
         private_key=ca_private_key,
         common_name=VAULT_CA_SUBJECT,
-        validity=365 * 50,
+        validity=timedelta(days=365 * 50),
     )
     return str(ca_private_key), str(ca_certificate)
 
@@ -505,7 +506,7 @@ def generate_vault_unit_certificate(
         ca=Certificate.from_string(ca_certificate),
         ca_private_key=PrivateKey.from_string(ca_private_key),
         csr=csr,
-        validity=365 * 50,
+        validity=timedelta(days=365 * 50),
     )
     return str(vault_private_key), str(vault_certificate)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -535,7 +535,7 @@ class VaultCharm(CharmBase):
         if existing_cert and existing_cert == provider_certificate.certificate:
             if not self._intermediate_ca_is_active(vault, existing_cert):
                 self.tls_certificates_pki.renew_certificate(
-                    csr=str(provider_certificate.certificate_signing_request),
+                    provider_certificate,
                 )
                 logger.debug("Renewing CA certificate")
                 return

--- a/src/charm.py
+++ b/src/charm.py
@@ -561,7 +561,7 @@ class VaultCharm(CharmBase):
                 allowed_domains=config_common_name,
                 mount=PKI_MOUNT,
                 role=PKI_ROLE_NAME,
-                max_ttl=issued_certificates_validity,
+                max_ttl=f"{issued_certificates_validity}s",
             )
         # Can run only after the first issuer has been actually created.
         try:
@@ -592,7 +592,7 @@ class VaultCharm(CharmBase):
         certificate_validity_seconds = certificate_validity.total_seconds()
         return certificate_validity_seconds > current_ttl
 
-    def _calculate_pki_certificates_validity(self, certificate: Certificate) -> str:
+    def _calculate_pki_certificates_validity(self, certificate: Certificate) -> int:
         """Calculate the maximum allowed validity of certificates issued by PKI.
 
         Return half the CA certificate validity.
@@ -601,8 +601,7 @@ class VaultCharm(CharmBase):
             raise ValueError("Invalid CA certificate with no expiry time or validity start time")
         ca_validity_time = certificate.expiry_time - certificate.validity_start_time
         ca_validity_seconds = ca_validity_time.total_seconds()
-        max_validity = int(ca_validity_seconds / 2)
-        return f"{str(max_validity)}s"
+        return int(ca_validity_seconds / 2)
 
     def _get_certificate_request(self) -> CertificateRequest | None:
         common_name = self._get_config_common_name()

--- a/src/charm.py
+++ b/src/charm.py
@@ -547,14 +547,16 @@ class VaultCharm(CharmBase):
             private_key=str(private_key),
             mount=PKI_MOUNT,
         )
+        issued_certificates_validity = self._calculate_pki_certificates_validity(
+            provider_certificate.certificate
+        )
         if not vault.is_common_name_allowed_in_pki_role(
             role=PKI_ROLE_NAME,
             mount=PKI_MOUNT,
             common_name=config_common_name,
+        ) or issued_certificates_validity != vault.get_role_max_ttl(
+            role=PKI_ROLE_NAME, mount=PKI_MOUNT
         ):
-            issued_certificates_validity = self._calculate_pki_certificates_validity(
-                provider_certificate.certificate
-            )
             vault.create_or_update_pki_charm_role(
                 allowed_domains=config_common_name,
                 mount=PKI_MOUNT,

--- a/tests/unit/certificates.py
+++ b/tests/unit/certificates.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from datetime import timedelta
 from typing import Tuple
 
 from charms.tls_certificates_interface.v4.tls_certificates import (
@@ -17,7 +18,9 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
 
 
 def generate_example_provider_certificate(
-    common_name: str, relation_id: int
+    common_name: str,
+    relation_id: int,
+    validity: timedelta = timedelta(days=365),
 ) -> Tuple[ProviderCertificate, PrivateKey]:
     private_key = generate_private_key()
     csr = generate_csr(
@@ -28,13 +31,13 @@ def generate_example_provider_certificate(
     ca_certificate = generate_ca(
         private_key=ca_private_key,
         common_name="ca.com",
-        validity=365,
+        validity=validity,
     )
     certificate = generate_certificate(
         csr=csr,
         ca=ca_certificate,
         ca_private_key=ca_private_key,
-        validity=365,
+        validity=validity,
     )
 
     provider_certificate = ProviderCertificate(
@@ -62,11 +65,14 @@ def generate_example_requirer_csr(common_name: str, relation_id: int) -> Require
 
 
 def sign_certificate(
-    ca_certificate: Certificate, ca_private_key: PrivateKey, csr: CertificateSigningRequest
+    ca_certificate: Certificate,
+    ca_private_key: PrivateKey,
+    csr: CertificateSigningRequest,
+    validity: timedelta = timedelta(days=365),
 ) -> Certificate:
     return generate_certificate(
         csr=csr,
         ca=ca_certificate,
         ca_private_key=ca_private_key,
-        validity=365,
+        validity=validity,
     )

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -22,6 +22,9 @@ class VaultCharmFixtures:
     patcher_pki_requirer_get_assigned_certificate = patch(
         "charm.TLSCertificatesRequiresV4.get_assigned_certificate"
     )
+    patcher_pki_requirer_renew_certificate = patch(
+        "charm.TLSCertificatesRequiresV4.renew_certificate"
+    )
     patcher_pki_provider_get_outstanding_certificate_requests = patch(
         "charm.TLSCertificatesProvidesV4.get_outstanding_certificate_requests"
     )
@@ -54,6 +57,9 @@ class VaultCharmFixtures:
         self.mock_pki_requirer_get_assigned_certificate = (
             VaultCharmFixtures.patcher_pki_requirer_get_assigned_certificate.start()
         )
+        self.mock_pki_requirer_renew_certificate = (
+            VaultCharmFixtures.patcher_pki_requirer_renew_certificate.start()
+        )
         self.mock_pki_provider_get_outstanding_certificate_requests = (
             VaultCharmFixtures.patcher_pki_provider_get_outstanding_certificate_requests.start()
         )
@@ -85,6 +91,9 @@ class VaultCharmFixtures:
             VaultCharmFixtures.patcher_kv_provides_get_credentials.start()
         )
         self.mock_get_binding = VaultCharmFixtures.patcher_get_binding.start()
+        self.mock_pki_requirer_renew_certificate = (
+            VaultCharmFixtures.patcher_pki_requirer_renew_certificate.start()
+        )
 
     @pytest.fixture(autouse=True)
     def context(self):

--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_tls.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_tls.py
@@ -4,6 +4,7 @@
 
 import os
 import tempfile
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 import pytest
@@ -234,7 +235,7 @@ class TestCharmTLS:
             ca_certificate = generate_ca(
                 common_name="ca",
                 private_key=ca_private_key,
-                validity=365,
+                validity=timedelta(days=365),
             )
             csr = generate_csr(
                 private_key=private_key,
@@ -244,7 +245,7 @@ class TestCharmTLS:
                 csr=csr,
                 ca=ca_certificate,
                 ca_private_key=ca_private_key,
-                validity=365,
+                validity=timedelta(days=365),
             )
             provider_certificate = ProviderCertificate(
                 certificate_signing_request=csr,
@@ -303,7 +304,7 @@ class TestCharmTLS:
         ca_certificate = generate_ca(
             common_name="ca",
             private_key=ca_private_key,
-            validity=365,
+            validity=timedelta(days=365),
         )
         csr = generate_csr(
             private_key=private_key,
@@ -313,7 +314,7 @@ class TestCharmTLS:
             csr=csr,
             ca=ca_certificate,
             ca_private_key=ca_private_key,
-            validity=365,
+            validity=timedelta(days=365),
         )
         patch_generate_certificate.return_value = certificate
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -414,7 +415,7 @@ class TestCharmTLS:
             ca_certificate = generate_ca(
                 common_name=VAULT_CA_SUBJECT,
                 private_key=ca_private_key,
-                validity=365,
+                validity=timedelta(days=365),
             )
             csr = generate_csr(
                 private_key=private_key,
@@ -424,7 +425,7 @@ class TestCharmTLS:
                 csr=csr,
                 ca=ca_certificate,
                 ca_private_key=ca_private_key,
-                validity=365,
+                validity=timedelta(days=365),
             )
             with open(temp_dir + "/ca.pem", "w") as f:
                 f.write(str(ca_certificate))
@@ -459,7 +460,7 @@ class TestCharmTLS:
         self_signed_ca_certificate = generate_ca(
             common_name=VAULT_CA_SUBJECT,
             private_key=self_signed_ca_private_key,
-            validity=365,
+            validity=timedelta(days=365),
         )
         self_signed_csr = generate_csr(
             private_key=self_signed_private_key,
@@ -469,7 +470,7 @@ class TestCharmTLS:
             csr=self_signed_csr,
             ca=self_signed_ca_certificate,
             ca_private_key=self_signed_ca_private_key,
-            validity=365,
+            validity=timedelta(days=365),
         )
         patch_generate_ca.return_value = self_signed_ca_certificate
         patch_generate_certificate.return_value = self_signed_certificate
@@ -513,7 +514,7 @@ class TestCharmTLS:
             tls_integration_ca_certificate = generate_ca(
                 common_name="tls integration ca",
                 private_key=tls_integration_ca_private_key,
-                validity=365,
+                validity=timedelta(days=365),
             )
             tls_integration_csr = generate_csr(
                 private_key=tls_integration_private_key,
@@ -523,7 +524,7 @@ class TestCharmTLS:
                 csr=tls_integration_csr,
                 ca=tls_integration_ca_certificate,
                 ca_private_key=tls_integration_ca_private_key,
-                validity=365,
+                validity=timedelta(days=365),
             )
             with open(temp_dir + "/ca.pem", "w") as f:
                 f.write(str(tls_integration_ca_certificate))

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -273,7 +273,7 @@ class TestCharmConfigure(VaultCharmFixtures):
             self.ctx.run(container.pebble_ready_event, state_in)
 
             self.mock_pki_requirer_renew_certificate.assert_called_once_with(
-                csr=str(provider_certificate.certificate_signing_request),
+                provider_certificate,
             )
 
     def test_given_vault_available_when_configure_then_certificate_is_provided(

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -309,6 +309,7 @@ class TestCharmConfigure(VaultCharmFixtures):
                 generate_example_provider_certificate(
                     common_name="myhostname.com",
                     relation_id=pki_relation_provider.relation_id,
+                    validity=timedelta(hours=24),
                 )
             )
             requirer_csr = generate_example_requirer_csr(
@@ -359,11 +360,13 @@ class TestCharmConfigure(VaultCharmFixtures):
 
             self.ctx.run(container.pebble_ready_event, state_in)
 
+            twelve_hours_in_seconds = 12 * 3600
             self.mock_vault.sign_pki_certificate_signing_request.assert_called_once_with(
                 mount="charm-pki",
                 role="charm",
                 csr=str(requirer_csr.certificate_signing_request),
                 common_name="subdomain.myhostname.com",
+                ttl=f"{twelve_hours_in_seconds}s",
             )
             self.mock_pki_provider_set_relation_certificate.assert_called_once_with(
                 provider_certificate=ProviderCertificate(

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -4,6 +4,7 @@
 
 
 import tempfile
+from datetime import timedelta
 
 import hcl
 import scenario
@@ -161,11 +162,14 @@ class TestCharmConfigure(VaultCharmFixtures):
                 leader=True,
                 secrets=[approle_secret],
                 relations=[peer_relation, pki_relation],
-                config={"common_name": "myhostname.com"},
+                config={
+                    "common_name": "myhostname.com",
+                },
             )
             provider_certificate, private_key = generate_example_provider_certificate(
                 common_name="myhostname.com",
                 relation_id=pki_relation.relation_id,
+                validity=timedelta(hours=24),
             )
             self.mock_pki_requirer_get_assigned_certificate.return_value = (
                 provider_certificate,
@@ -185,10 +189,91 @@ class TestCharmConfigure(VaultCharmFixtures):
             self.mock_vault.make_latest_pki_issuer_default.assert_called_once_with(
                 mount="charm-pki",
             )
+            twelve_hours_in_seconds = 12 * 3600
             self.mock_vault.create_or_update_pki_charm_role.assert_called_once_with(
                 allowed_domains="myhostname.com",
                 mount="charm-pki",
                 role="charm",
+                max_ttl=f"{twelve_hours_in_seconds}s",
+            )
+
+    def test_given_pki_intermediate_certificate_inactive_when_configure_then_certificate_is_renewed(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_vault.configure_mock(
+                **{
+                    "is_api_available.return_value": True,
+                    "authenticate.return_value": True,
+                    "is_initialized.return_value": True,
+                    "is_sealed.return_value": False,
+                    "is_active_or_standby.return_value": True,
+                    "get_intermediate_ca.return_value": "",
+                    "is_common_name_allowed_in_pki_role.return_value": False,
+                },
+            )
+            self.mock_autounseal_requires_get_details.return_value = None
+            vault_config_mount = scenario.Mount(
+                location="/vault/config",
+                src=temp_dir,
+            )
+            container = scenario.Container(
+                name="vault",
+                can_connect=True,
+                mounts={
+                    "vault-config": vault_config_mount,
+                },
+            )
+            peer_relation = scenario.PeerRelation(
+                endpoint="vault-peers",
+            )
+            pki_relation = scenario.Relation(
+                endpoint="tls-certificates-pki",
+                interface="tls-certificates",
+            )
+            approle_secret = scenario.Secret(
+                id="0",
+                label="vault-approle-auth-details",
+                contents={0: {"role-id": "role id", "secret-id": "secret id"}},
+            )
+            state_in = scenario.State(
+                containers=[container],
+                leader=True,
+                secrets=[approle_secret],
+                relations=[peer_relation, pki_relation],
+                config={
+                    "common_name": "myhostname.com",
+                },
+            )
+            provider_certificate, private_key = generate_example_provider_certificate(
+                common_name="myhostname.com",
+                relation_id=pki_relation.relation_id,
+                validity=timedelta(hours=24),
+            )
+            self.mock_pki_requirer_get_assigned_certificate.return_value = (
+                provider_certificate,
+                private_key,
+            )
+
+            self.ctx.run(container.pebble_ready_event, state_in)
+            state_in = scenario.State(
+                containers=[container],
+                leader=True,
+                secrets=[approle_secret],
+                relations=[peer_relation, pki_relation],
+                config={
+                    "common_name": "myhostname.com",
+                },
+            )
+            # Imitate ttl of issued certificates (by pki role) being longer than the CA validity
+            self.mock_vault.get_role_max_ttl.return_value = "25h"
+            self.mock_vault.get_intermediate_ca.return_value = str(
+                provider_certificate.certificate
+            )
+            self.ctx.run(container.pebble_ready_event, state_in)
+
+            self.mock_pki_requirer_renew_certificate.assert_called_once_with(
+                csr=str(provider_certificate.certificate_signing_request),
             )
 
     def test_given_vault_available_when_configure_then_certificate_is_provided(

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -266,7 +266,7 @@ class TestCharmConfigure(VaultCharmFixtures):
                 },
             )
             # Imitate ttl of issued certificates (by pki role) being longer than the CA validity
-            self.mock_vault.get_role_max_ttl.return_value = "25h"
+            self.mock_vault.get_role_max_ttl.return_value = 25 * 3600
             self.mock_vault.get_intermediate_ca.return_value = str(
                 provider_certificate.certificate
             )


### PR DESCRIPTION
# Description

Fixes #500 

- Checks if there is a CA that can issue certificates (Vault does not allow issuing certificates that would outlast the CA)
- Sets the ttl of the pki role to half of the validity of the CA, this will be used by Vault to set validity of issued certificates
- Adds a unit test

**Note to reviewer**: 
- It might help to read spec TE118 while reviewing this.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
