### PR TITLE
chore: Upload charm to latest/edge when main branch is updated

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -25,7 +25,17 @@ jobs:
         id: charm-path
         run: echo "charm_path=$(find . -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
 
-      - name: Upload charm to Charmhub
+      - name: Upload the charm to Charmhub's latest track
+        # This workflow should only run on the main branch.
+        if: github.ref_name == 'main'
+        uses: canonical/charming-actions/upload-charm@2.6.3
+        with:
+          built-charm-path: ${{ steps.charm-path.outputs.charm_path }}
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: latest/edge
+
+      - name: Upload the charm to Charmhub's 1.16/edge track
         uses: canonical/charming-actions/upload-charm@2.6.3
         with:
           built-charm-path: ${{ steps.charm-path.outputs.charm_path }}


### PR DESCRIPTION
# Description

Currently we only release the charm to the release tracks (`1.15` and `1.16`).
In this change we add a workflow to release to `latest/edge. This track will follow main which means it will have the same revision as in `1.16/edge` for now and later when there is a new release it will follow that release (for example `1.17`)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
