### PR TITLE
chore: bump python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,15 +12,15 @@ attrs==24.2.0
     # via
     #   jsonschema
     #   referencing
-boto3==1.35.49
+boto3==1.35.55
     # via -r requirements.in
-boto3-stubs[s3]==1.35.49
+boto3-stubs[s3]==1.35.55
     # via -r requirements.in
-botocore==1.35.49
+botocore==1.35.55
     # via
     #   boto3
     #   s3transfer
-botocore-stubs==1.35.49
+botocore-stubs==1.35.54
     # via boto3-stubs
 certifi==2024.8.30
     # via
@@ -57,7 +57,7 @@ idna==3.10
     #   anyio
     #   httpx
     #   requests
-importlib-metadata==8.4.0
+importlib-metadata==8.5.0
     # via opentelemetry-api
 iniconfig==2.0.0
     # via pytest
@@ -71,7 +71,7 @@ jsonschema==4.23.0
     # via -r requirements.in
 jsonschema-specifications==2024.10.1
     # via jsonschema
-lightkube==0.15.4
+lightkube==0.15.5
     # via
     #   -r requirements.in
     #   cosl
@@ -83,22 +83,22 @@ markupsafe==3.0.2
     # via jinja2
 mypy-boto3-s3==1.35.46
     # via boto3-stubs
-opentelemetry-api==1.27.0
+opentelemetry-api==1.28.0
     # via
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp-proto-common==1.27.0
+opentelemetry-exporter-otlp-proto-common==1.28.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-http==1.27.0
+opentelemetry-exporter-otlp-proto-http==1.28.0
     # via -r requirements.in
-opentelemetry-proto==1.27.0
+opentelemetry-proto==1.28.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.27.0
+opentelemetry-sdk==1.28.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.48b0
+opentelemetry-semantic-conventions==0.49b0
     # via opentelemetry-sdk
 ops==2.17.0
     # via
@@ -111,7 +111,7 @@ packaging==24.1
     # via pytest
 pluggy==1.5.0
     # via pytest
-protobuf==4.25.5
+protobuf==5.28.3
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -40,7 +40,7 @@ durationpy==0.9
     # via kubernetes
 executing==2.1.0
     # via stack-data
-google-auth==2.35.0
+google-auth==2.36.0
     # via kubernetes
 hvac==2.3.0
     # via
@@ -103,7 +103,7 @@ pluggy==1.5.0
     #   pytest
 prompt-toolkit==3.0.48
     # via ipython
-protobuf==4.25.5
+protobuf==5.28.3
     # via
     #   -c requirements.txt
     #   macaroonbakery
@@ -135,7 +135,7 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pyright==1.1.386
+pyright==1.1.388
     # via -r test-requirements.in
 pytest==8.3.3
     # via
@@ -172,7 +172,7 @@ requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
-ruff==0.7.1
+ruff==0.7.2
     # via -r test-requirements.in
 six==1.16.0
     # via


### PR DESCRIPTION
# Description

For some reason dependabot struggles to update our dependencies, here we manually run pip-compile to get new versions.

Supersedes #525

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
