### PR TITLE
fix: remove dead server pruning

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -436,26 +436,6 @@ class Vault:
         response = self._client.adapter.get(RAFT_STATE_ENDPOINT)
         return response["data"]
 
-    def update_autopilot_config(self) -> None:
-        """Set Vault to clean up dead servers automatically.
-
-        Read more about it here: https://developer.hashicorp.com/vault/api-docs/system/storage/raftautopilot#set-configuration
-
-        """
-        params = {
-            "cleanup_dead_servers": True,
-            "dead_server_last_contact_threshold": "1m",
-            "min_quorum": 3,
-        }
-        api_path = "/v1/sys/storage/raft/autopilot/configuration"
-        try:
-            self._client.adapter.post(
-                url=api_path,
-                json=params,
-            )
-        except InvalidRequest as e:
-            raise VaultClientError(e) from e
-
     def is_raft_cluster_healthy(self) -> bool:
         """Check if raft cluster is healthy."""
         return self.get_raft_cluster_state()["healthy"]

--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -28,7 +28,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 20
+LIBPATCH = 21
 
 
 RAFT_STATE_ENDPOINT = "v1/sys/storage/raft/autopilot/state"

--- a/src/charm.py
+++ b/src/charm.py
@@ -758,7 +758,6 @@ class VaultCharm(CharmBase):
 
         try:
             vault.enable_audit_device(device_type=AuditDeviceType.FILE, path="stdout")
-            vault.update_autopilot_config()
             vault.enable_approle_auth_method()
             vault.configure_policy(policy_name=CHARM_POLICY_NAME, policy_path=CHARM_POLICY_PATH)
             cidrs = [f"{self._bind_address}/24"]

--- a/tests/unit/test_charm_authorize_action.py
+++ b/tests/unit/test_charm_authorize_action.py
@@ -139,7 +139,6 @@ class TestCharmAuthorizeAction(VaultCharmFixtures):
         self.mock_vault.enable_audit_device.assert_called_once_with(
             device_type=AuditDeviceType.FILE, path="stdout"
         )
-        self.mock_vault.update_autopilot_config.assert_called_once()
         self.mock_vault.enable_approle_auth_method.assert_called_once()
         self.mock_vault.configure_policy.assert_called_once_with(
             policy_name="charm-access",


### PR DESCRIPTION
# Description

When deploying Vault with multiple units and pods restart, they do not come back online. Vault seems to be pruning them because they have been offline for too long and do not accept them to come back. 

Here we get rid of this automatic dead server pruning and only remove nodes from the cluster on remove event. 

Fixes #523 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
