### PR TITLE
chore: Ignore charm tracing buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__/
 
 *.pem
 tests/integration/vault_kv_requirer_operator/lib/charms/vault_k8s/v0/vault_kv.py
+.charm_tracing_buffer.raw


### PR DESCRIPTION
Ignores the (generated) charm tracing buffer file

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
