### PR TITLE
feat: Implement the JujuFacade wrapper class

### DIFF
--- a/lib/charms/vault_k8s/v0/juju_facade.py
+++ b/lib/charms/vault_k8s/v0/juju_facade.py
@@ -2,6 +2,7 @@
 
 import logging
 from datetime import datetime
+from itertools import chain
 from pathlib import Path
 from typing import List, Literal, cast
 
@@ -421,9 +422,8 @@ class JujuFacade(Object):
         relation = self.get_relation_by_id(relation_name, relation_id)
         if not relation:
             raise NoSuchRelationError(f"Relation {relation_name}:{relation_id} not found")
-        if not all(isinstance(value, str) for value in data.values()) or not all(
-            isinstance(key, str) for key in data.keys()
-        ):
+
+        if not all(isinstance(value, str) for value in chain(data.values(), data.keys())):
             raise InvalidRelationDataError("Invalid relation data")
         try:
             logger.info("Setting relation data for %s:%d", relation_name, relation_id)

--- a/lib/charms/vault_k8s/v0/juju_facade.py
+++ b/lib/charms/vault_k8s/v0/juju_facade.py
@@ -67,6 +67,10 @@ class NoSuchStorageError(FacadeError):
     """Exception raised when a storage does not exist."""
 
 
+class SecretAccessDeniedError(FacadeError):
+    """Exception raised if the charm does not have permission to access the secret."""
+
+
 class JujuFacade(Object):
     """Juju API wrapper class."""
 
@@ -146,7 +150,7 @@ class JujuFacade(Object):
             raise SecretRemovedError(e) from e
         except ModelError as e:
             logger.error("Error getting secret content for %s: %s", label, e)
-            raise TransientJujuError(e) from e
+            raise SecretAccessDeniedError(e) from e
 
     def get_current_secret_content(self, label: str, id: str | None = None) -> dict[str, str]:
         """Get secret content if the secret exists and return currently tracked revision.

--- a/lib/charms/vault_k8s/v0/juju_facade.py
+++ b/lib/charms/vault_k8s/v0/juju_facade.py
@@ -1,0 +1,398 @@
+"""This library provides a wrapper of the Juju API."""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import List, Literal, cast
+
+from ops.charm import CharmBase
+from ops.framework import Object
+from ops.model import (
+    Application,
+    ModelError,
+    Relation,
+    RelationDataContent,
+    RelationDataError,
+    Secret,
+    SecretNotFoundError,
+    Unit,
+)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "7702b17f87ea4f1180dfcbf5bf46bea8"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+logger = logging.getLogger(__name__)
+
+
+class FacadeError(Exception):
+    """Base class for custom errors raised by this library."""
+
+
+class TransientJujuError(FacadeError):
+    """Exception raised for transient Juju errors like ModelError."""
+
+
+class SecretValidationError(FacadeError):
+    """Exception raised for secret validation errors."""
+
+
+class NoSuchSecretError(FacadeError):
+    """Exception raised when a secret does not exist."""
+
+
+class SecretRemovedError(FacadeError):
+    """Exception raised when a secret does not exist anymore."""
+
+
+class NoSuchRelationError(FacadeError):
+    """Exception raised when a relation does not exist."""
+
+
+class InvalidRelationDataError(FacadeError):
+    """Exception raised when relation data is invalid."""
+
+
+class NotLeaderError(FacadeError):
+    """Exception raised when the unit is not leader."""
+
+
+class NoSuchStorageError(FacadeError):
+    """Exception raised when a storage does not exist."""
+
+
+class JujuFacade(Object):
+    """Juju API wrapper class."""
+
+    def __init__(self, charm: CharmBase):
+        super().__init__(charm, "juju_facade")
+        self.charm = charm
+
+    # Secret related methods
+    def get_secret(self, label: str, id: str | None = None) -> Secret:
+        """Retrieve a secret and handle SecretNotFound error."""
+        try:
+            return (
+                self.charm.model.get_secret(label=label, id=id)
+                if id
+                else self.charm.model.get_secret(label=label)
+            )
+        except SecretNotFoundError as e:
+            logger.warning("Secret %s not found: %s", label, e)
+            raise NoSuchSecretError(e) from e
+        except ModelError as e:
+            logger.error("Error getting secret %s: %s", label, e)
+            raise TransientJujuError(e) from e
+
+    def secret_exists(self, label: str, id: str | None = None) -> bool:
+        """Check if the secret exists."""
+        try:
+            self.get_secret(label=label, id=id)
+            return True
+        except NoSuchSecretError:
+            return False
+        except FacadeError:
+            raise
+
+    def secret_exists_with_fields(
+        self, fields: tuple[str, ...], label: str, id: str | None = None
+    ) -> bool:
+        """Check if the secret exists and has the right fields."""
+        try:
+            secret_content = self._get_secret_content(label=label, id=id)
+            return all(secret_content.get(field) for field in fields)
+        except NoSuchSecretError:
+            return False
+        except FacadeError:
+            raise
+
+    def _get_secret_content(
+        self, label: str, id: str | None = None, refresh: bool = False
+    ) -> dict[str, str]:
+        try:
+            secret = self.get_secret(label=label, id=id)
+            return secret.get_content(refresh=refresh)
+        except NoSuchSecretError:
+            raise
+        except SecretNotFoundError as e:
+            logger.warning("Secret %s not found: %s", label, e)
+            raise SecretRemovedError(e) from e
+        except ModelError as e:
+            logger.error("Error getting secret content for %s: %s", label, e)
+            raise TransientJujuError(e) from e
+
+    def get_current_secret_content(self, label: str, id: str | None = None) -> dict[str, str]:
+        """Get secret content if the secret exists and returns currently tracked revision."""
+        try:
+            return self._get_secret_content(label=label, id=id)
+        except FacadeError:
+            raise
+
+    def get_latest_secret_content(self, label: str, id: str | None = None) -> dict[str, str]:
+        """Get secret content if the secret exists and returns latest revision."""
+        try:
+            return self._get_secret_content(label=label, id=id, refresh=True)
+        except FacadeError:
+            raise
+
+    def get_secret_content_values(
+        self, *keys: str, label: str, id: str | None = None
+    ) -> tuple[str | None, ...] | None:
+        """Get secret content values by keys."""
+        try:
+            secret_content = self._get_secret_content(label=label, id=id)
+            if not secret_content:
+                return None
+            for key in keys:
+                if key not in secret_content:
+                    logger.warning("Secret %s does not have key %s", label, key)
+            return tuple(secret_content.get(key, None) for key in keys)
+        except FacadeError:
+            raise
+
+    def _add_app_secret(self, content: dict[str, str], label: str) -> Secret:
+        """Add a secret to the application."""
+        try:
+            secret = self.charm.app.add_secret(content, label=label)
+            logger.info("Secret %s added to application", label)
+            return secret
+        except ValueError as e:
+            logger.error("Invalid secret content %s: %s", content, e)
+            raise SecretValidationError(e) from e
+
+    def _add_unit_secret(self, content: dict[str, str], label: str) -> Secret:
+        """Add a secret to the unit."""
+        try:
+            secret = self.charm.unit.add_secret(content, label=label)
+            logger.info("Secret %s added to unit", label)
+            return secret
+        except ValueError as e:
+            logger.error("Invalid secret content %s: %s", content, e)
+            raise SecretValidationError(e) from e
+
+    def _set_secret_content(
+        self,
+        content: dict[str, str],
+        label: str,
+        id: str | None = None,
+        unit_or_app: Literal["unit", "app"] = "app",
+    ) -> Secret:
+        try:
+            secret = self.get_secret(label=label, id=id)
+            current_content = self.get_latest_secret_content(label=label, id=id)
+        except TransientJujuError:
+            raise
+        except (NoSuchSecretError, SecretRemovedError):
+            if unit_or_app == "app":
+                return self._add_app_secret(content, label)
+            return self._add_unit_secret(content, label)
+        try:
+            if current_content == content:
+                logger.info("Secret %s already has the requested content, skipping", label)
+                return secret
+            logger.info("Setting secret content to %s", label)
+            secret.set_content(content)
+            return secret
+        except ModelError as e:
+            logger.error("Error setting secret content for %s: %s", label, e)
+            raise TransientJujuError(e) from e
+
+    def set_app_secret_content(
+        self, content: dict[str, str], label: str, id: str | None = None
+    ) -> Secret:
+        """Set the secret content if the secret exists.
+
+        Creates new secret revision
+        """
+        try:
+            return self._set_secret_content(content=content, label=label, id=id, unit_or_app="app")
+        except FacadeError:
+            raise
+
+    def set_unit_secret_content(
+        self, content: dict[str, str], label: str, id: str | None = None
+    ) -> Secret:
+        """Set the secret content if the secret exists."""
+        try:
+            return self._set_secret_content(
+                content=content, label=label, id=id, unit_or_app="unit"
+            )
+        except FacadeError:
+            raise
+
+    def set_secret_label(self, new_label: str, label: str, id: str | None = None) -> None:
+        """Set a new label for the secret if the secret exists."""
+        try:
+            secret = self.get_secret(label=label, id=id)
+            secret.set_info(label=new_label)
+        except FacadeError:
+            raise
+
+    def set_secret_expiry(self, expiry: datetime, label: str, id: str | None = None) -> None:
+        """Set a new expiry date for the secret if the secret exists."""
+        try:
+            secret = self.get_secret(label=label, id=id)
+            secret.set_info(expire=expiry)
+        except FacadeError:
+            raise
+
+    # Relation related methods
+    # is it possible not to know the name?
+    def get_relation_by_id(self, relation_name: str, relation_id: int) -> Relation | None:
+        """Get the relation object by name and id."""
+        relation = self.charm.model.get_relation(relation_name, relation_id)
+        if not relation:
+            logger.error("Relation %s:%d not found", relation_name, relation_id)
+            return None
+        return relation
+
+    def get_relations(self, relation_name: str) -> List[Relation]:
+        """Get all relation objects with the given name."""
+        relations = self.charm.model.relations.get(relation_name, [])
+        if not relations:
+            logger.error("No relations found for %s", relation_name)
+        return relations
+
+    def relation_exists(self, relation_name: str) -> bool:
+        """Check if there are any relations with the given name."""
+        return self.get_relations(relation_name) != []
+
+    def _read_relation_data(
+        self, relation_name: str, relation_id: int, entity: Unit | Application
+    ) -> RelationDataContent | dict[str, str]:
+        relation = self.get_relation_by_id(relation_name, relation_id)
+        if not relation:
+            raise NoSuchRelationError(f"Relation {relation_name}:{relation_id} not found")
+        return relation.data.get(entity, {})
+
+    def get_app_relation_data(
+        self, relation_name: str, relation_id: int
+    ) -> RelationDataContent | dict[str, str]:
+        """Get relation data from the caller's application databag."""
+        return self._read_relation_data(relation_name, relation_id, self.charm.model.app)
+
+    def get_remote_app_relation_data(
+        self, relation_name: str, relation_id: int
+    ) -> RelationDataContent | dict[str, str]:
+        """Get relation data from the remote application databag."""
+        return self._read_relation_data(relation_name, relation_id, self.charm.model.app)
+
+    def get_unit_relation_data(
+        self, relation_name: str, relation_id: int
+    ) -> RelationDataContent | dict[str, str]:
+        """Get relation data from the remote unit databag."""
+        return self._read_relation_data(relation_name, relation_id, self.charm.model.unit)
+
+    def get_remote_units_relation_data(
+        self, relation_name: str, relation_id: int
+    ) -> List[RelationDataContent | dict[str, str]]:
+        """Get relation data from the remote units databags."""
+        relation = self.get_relation_by_id(relation_name, relation_id)
+        if not relation:
+            raise NoSuchRelationError(f"Relation {relation_name}:{relation_id} not found")
+        return [relation.data.get(unit, {}) for unit in relation.units]
+
+    def _set_relation_data(
+        self,
+        data: dict[str, str],
+        relation_name: str,
+        relation_id: int,
+        entity: Unit | Application,
+    ) -> None:
+        relation = self.get_relation_by_id(relation_name, relation_id)
+        if not relation:
+            raise NoSuchRelationError(f"Relation {relation_name}:{relation_id} not found")
+        if not all(isinstance(value, str) for value in data.values()) or not all(
+            isinstance(key, str) for key in data.keys()
+        ):
+            raise InvalidRelationDataError("Invalid relation data")
+        try:
+            logger.info("Setting relation data for %s:%d", relation_name, relation_id)
+            relation.data[entity].update(data)
+        except RelationDataError as e:
+            logger.error(
+                "Error setting relation data for %s:%d: %s", relation_name, relation_id, e
+            )
+            raise InvalidRelationDataError(e) from e
+
+    def set_app_relation_data(
+        self, data: dict[str, str], relation_name: str, relation_id: int
+    ) -> None:
+        """Set relation data in the caller's application databag."""
+        if not self.charm.model.unit.is_leader():
+            raise NotLeaderError("Action not allowed for non-leader units")
+        try:
+            self._set_relation_data(
+                data=data,
+                relation_name=relation_name,
+                relation_id=relation_id,
+                entity=self.charm.model.app,
+            )
+        except FacadeError:
+            raise
+
+    def set_unit_relation_data(
+        self, data: dict[str, str], relation_name: str, relation_id: int
+    ) -> None:
+        """Set relation data in the caller's unit databag."""
+        try:
+            self._set_relation_data(
+                data=data,
+                relation_name=relation_name,
+                relation_id=relation_id,
+                entity=self.charm.model.unit,
+            )
+        except FacadeError:
+            raise
+
+    # Charm config related methods
+    def get_string_config(self, key: str) -> str | None:
+        """Get a string config value."""
+        return cast(str, self.charm.model.config.get(key))
+
+    def get_int_config(self, key: str) -> int | None:
+        """Get an integer config value."""
+        return cast(int, self.charm.model.config.get(key))
+
+    def get_bool_config(self, key: str) -> bool | None:
+        """Get a boolean config value."""
+        return cast(bool, self.charm.model.config.get(key))
+
+    # Other functions
+    def get_storage_location(self, storage_name: str) -> Path:
+        """Get the storage location."""
+        storages = self.charm.model.storages
+        if not storages[storage_name]:
+            raise NoSuchStorageError(f"Storage {storage_name} not found")
+        return storages[storage_name][0].location
+
+    @property
+    def model_name(self) -> str:
+        """Get the model name."""
+        return self.charm.model.name
+
+    @property
+    def app_name(self) -> str:
+        """Get the application name."""
+        return self.charm.app.name
+
+    @property
+    def unit_name(self) -> str:
+        """Get the unit name."""
+        return self.charm.unit.name
+
+    @property
+    def model_storage_names(self) -> List[str]:
+        """Get the model storage names."""
+        return list(self.charm.model.storages.keys())
+
+    @property
+    def is_leader(self) -> bool:
+        """Check if the unit is leader."""
+        return self.charm.unit.is_leader()

--- a/tests/unit/lib/charms/vault_k8s/v0/test_juju_facade.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_juju_facade.py
@@ -1,0 +1,265 @@
+from datetime import datetime, timedelta
+from typing import cast
+from unittest.mock import Mock
+
+import pytest
+from charms.vault_k8s.v0.juju_facade import (
+    InvalidRelationDataError,
+    JujuFacade,
+    NoSuchRelationError,
+    NoSuchSecretError,
+    NoSuchStorageError,
+    NotLeaderError,
+    SecretRemovedError,
+    TransientJujuError,
+)
+from ops.model import ModelError, SecretNotFoundError
+
+
+class TestJujuFacade:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        charm = Mock()
+        charm.model = Mock(storages={"storage": []})
+        charm.app = Mock()
+        charm.unit = Mock()
+        self.facade = JujuFacade(charm)
+
+    # Tests for Secret methods
+
+    def test_given_model_error_when_get_secret_then_raises_transient_error(self):
+        self.facade.charm.model.get_secret = Mock(side_effect=ModelError())
+
+        with pytest.raises(TransientJujuError):
+            self.facade.get_secret("test-secret")
+
+    def test_given_model_error_when_secret_exists_then_raises_transient_error(self):
+        self.facade.charm.model.get_secret = Mock(side_effect=ModelError())
+
+        with pytest.raises(TransientJujuError):
+            self.facade.secret_exists("test-secret")
+
+    def test_given_secret_not_found_when_secret_exists_then_returns_false(self):
+        self.facade.charm.model.get_secret = Mock(side_effect=SecretNotFoundError())
+
+        assert not self.facade.secret_exists("test-secret")
+
+    def test_given_secret_exists_with_exact_fields_when_secret_exists_with_fields_then_returns_true(
+        self,
+    ):
+        secret = Mock()
+        self.facade.charm.model.get_secret = Mock(return_value=secret)
+        secret.get_content = Mock(return_value={"key": "value"})
+
+        assert self.facade.secret_exists_with_fields(("key",), "test-secret")
+
+    def test_given_secret_exists_with_missing_fields_when_secret_exists_with_fields_then_returns_false(
+        self,
+    ):
+        secret = Mock()
+        self.facade.charm.model.get_secret = Mock(return_value=secret)
+        secret.get_content = Mock(return_value={"key": "value"})
+
+        assert not self.facade.secret_exists_with_fields(("key1",), "test-secret")
+
+    def test_given_secret_not_found_when_secret_exists_with_fields_then_returns_false(self):
+        self.facade.charm.model.get_secret = Mock(side_effect=SecretNotFoundError())
+
+        assert not self.facade.secret_exists_with_fields(("key",), "test-secret")
+
+    def test_given_secret_removed_when_get_secret_content_values_then_raises_no_such_secret(self):
+        secret = Mock()
+        self.facade.charm.model.get_secret = Mock(return_value=secret)
+        secret.get_content = Mock(side_effect=SecretNotFoundError())
+
+        with pytest.raises(SecretRemovedError):
+            self.facade.get_current_secret_content("test-secret")
+
+    def test_given_model_error_when_get_secret_content_values_then_raises_transient_error(self):
+        self.facade.charm.model.get_secret = Mock(side_effect=ModelError())
+
+        with pytest.raises(TransientJujuError):
+            self.facade.get_current_secret_content("test-secret")
+
+    def test_given_secret_when_get_latest_secret_content_then_secret_is_refreshed(self):
+        secret = Mock()
+        secret.get_content = Mock(return_value={"key": "value"})
+        self.facade.charm.model.get_secret = Mock(return_value=secret)
+
+        assert self.facade.get_latest_secret_content("test-secret") == {"key": "value"}
+        secret.get_content.assert_called_with(refresh=True)
+
+    def test_given_secret_when_get_secret_content_values_then_returns_specified_values_only(self):
+        secret = Mock()
+        secret.get_content = Mock(
+            return_value={"key1": "value1", "key2": "value2", "key3": "value3"}
+        )
+        self.facade.charm.model.get_secret = Mock(return_value=secret)
+
+        assert self.facade.get_secret_content_values("key1", "key3", label="test-secret") == (
+            "value1",
+            "value3",
+        )
+
+    def test_given_secret_exists_when_set_app_secret_content_with_same_content_then_skips_update(
+        self,
+    ):
+        secret = Mock()
+        content = {"key": "value"}
+        secret.get_content = Mock(return_value=content)
+        self.facade.charm.model.get_secret = Mock(return_value=secret)
+
+        result = self.facade.set_app_secret_content(content, "test-label")
+
+        assert secret.set_content.not_called()
+        assert result == secret
+
+    def test_given_secret_not_exists_when_set_app_secret_content_then_creates_new_secret(self):
+        self.facade.charm.model.get_secret = Mock(side_effect=SecretNotFoundError())
+        content = {"key": "value"}
+        new_secret = Mock()
+        self.facade.charm.app.add_secret = Mock(return_value=new_secret)
+
+        result = self.facade.set_app_secret_content(content, "test-label")
+
+        self.facade.charm.app.add_secret.assert_called_once_with(content, label="test-label")
+        assert result == new_secret
+
+    def test_given_secret_exists_when_set_unit_secret_content_with_same_content_then_skips_update(
+        self,
+    ):
+        secret = Mock()
+        content = {"key": "value"}
+        secret.get_content = Mock(return_value=content)
+        self.facade.charm.model.get_secret = Mock(return_value=secret)
+
+        result = self.facade.set_unit_secret_content(content, "test-label")
+        secret.set_content.assert_not_called()
+        assert result == secret
+
+    def test_given_secret_not_exists_when_set_unit_secret_content_then_creates_new_secret(self):
+        self.facade.charm.model.get_secret = Mock(side_effect=SecretNotFoundError())
+        content = {"key": "value"}
+        new_secret = Mock()
+        self.facade.charm.unit.add_secret = Mock(return_value=new_secret)
+
+        result = self.facade.set_unit_secret_content(content, "test-label")
+        assert result == new_secret
+
+    def test_given_secret_when_set_secret_label_then_secret_label_is_updated(self):
+        secret = Mock()
+        self.facade.charm.model.get_secret = Mock(return_value=secret)
+
+        self.facade.set_secret_label("new-label", "test-label")
+        secret.set_info.assert_called_with(label="new-label")
+
+    def test_given_secret_not_found_when_set_secret_label_then_raises_no_such_secret(self):
+        self.facade.charm.model.get_secret = Mock(side_effect=SecretNotFoundError())
+
+        with pytest.raises(NoSuchSecretError):
+            self.facade.set_secret_label("new-label", "test-label")
+
+    def test_given_model_error_when_set_secret_label_then_raises_transient_error(self):
+        self.facade.charm.model.get_secret = Mock(side_effect=ModelError())
+
+        with pytest.raises(TransientJujuError):
+            self.facade.set_secret_label("new-label", "test-label")
+
+    def test_given_secret_when_set_secret_expiry_then_secret_expiry_is_updated(self):
+        secret = Mock()
+        self.facade.charm.model.get_secret = Mock(return_value=secret)
+
+        expiry = datetime.now() + timedelta(days=1)
+        self.facade.set_secret_expiry(expiry, "test-label")
+
+        actual_expiry = secret.set_info.call_args[1]["expire"]
+        assert actual_expiry.timestamp() == expiry.timestamp()
+
+    def test_given_secret_not_found_when_set_secret_expiry_then_raises_no_such_secret(self):
+        self.facade.charm.model.get_secret = Mock(side_effect=SecretNotFoundError())
+
+        with pytest.raises(NoSuchSecretError):
+            self.facade.set_secret_expiry(datetime.now() + timedelta(days=1), "test-label")
+
+    def test_given_model_error_when_set_secret_expiry_then_raises_transient_error(self):
+        self.facade.charm.model.get_secret = Mock(side_effect=ModelError())
+
+        with pytest.raises(TransientJujuError):
+            self.facade.set_secret_expiry(datetime.now() + timedelta(days=1), "test-label")
+
+    # Tests for Relation methods
+
+    def test_given_relation_not_found_when_get_app_relation_data_then_raises_no_such_relation(
+        self,
+    ):
+        self.facade.charm.model.get_relation = Mock(return_value=None)
+
+        with pytest.raises(NoSuchRelationError):
+            self.facade.get_app_relation_data("test-relation", 1)
+
+    def test_given_relation_not_found_when_get_remote_app_relation_data_then_raises_no_such_relation(
+        self,
+    ):
+        self.facade.charm.model.get_relation = Mock(return_value=None)
+
+        with pytest.raises(NoSuchRelationError):
+            self.facade.get_remote_app_relation_data("test-relation", 1)
+
+    def test_given_relation_not_found_when_get_unit_relation_data_then_raises_no_such_relation(
+        self,
+    ):
+        self.facade.charm.model.get_relation = Mock(return_value=None)
+
+        with pytest.raises(NoSuchRelationError):
+            self.facade.get_unit_relation_data("test-relation", 1)
+
+    def test_given_relation_when_get_remote_units_relation_data_then_returns_list_of_relation_data(
+        self,
+    ):
+        relation = Mock()
+        relation.units = ["unit-1", "unit-2"]
+        relation.data = {"unit-1": {"key": "value1"}, "unit-2": {"key": "value2"}}
+        self.facade.charm.model.get_relation = Mock(return_value=relation)
+
+        assert self.facade.get_remote_units_relation_data("test-relation", 1) == [
+            {"key": "value1"},
+            {"key": "value2"},
+        ]
+
+    def test_given_not_leader_when_set_app_relation_data_then_raises_not_leader(self):
+        self.facade.charm.model.unit.is_leader = Mock(return_value=False)
+
+        with pytest.raises(NotLeaderError):
+            self.facade.set_app_relation_data({"key": "value"}, "test-relation", 1)
+
+    def test_given_relation_not_found_when_set_app_relation_data_then_raises_no_such_relation(
+        self,
+    ):
+        self.facade.charm.model.get_relation = Mock(return_value=None)
+
+        with pytest.raises(NoSuchRelationError):
+            self.facade.set_app_relation_data({"key": "value"}, "test-relation", 1)
+
+    def test_given_relation_not_found_when_set_unit_relation_data_then_raises_no_such_relation(
+        self,
+    ):
+        self.facade.charm.model.get_relation = Mock(return_value=None)
+
+        with pytest.raises(NoSuchRelationError):
+            self.facade.set_unit_relation_data({"key": "value"}, "test-relation", 1)
+
+    def test_given_invalid_data_when_set_relation_data_then_raises_invalid_data(self):
+        relation = Mock()
+        self.facade.get_relation_by_id = Mock(return_value=relation)
+
+        data = {"key": 123}  # int value
+        with pytest.raises(InvalidRelationDataError):
+            self.facade.set_app_relation_data(cast(dict[str, str], data), "test-relation", 1)
+
+    # Tests for Storage methods
+
+    def test_given_storage_not_exists_when_get_storage_location_then_raises_no_such_storage(
+        self,
+    ):
+        with pytest.raises(NoSuchStorageError):
+            self.facade.get_storage_location("storage")

--- a/tests/unit/lib/charms/vault_k8s/v0/test_juju_facade.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_juju_facade.py
@@ -189,6 +189,12 @@ class TestJujuFacade:
 
     # Tests for Relation methods
 
+    def test_given_relation_not_found_when_get_relation_by_id_then_raises_no_such_relation(self):
+        self.facade.charm.model.get_relation = Mock(return_value=None)
+
+        with pytest.raises(NoSuchRelationError):
+            self.facade.get_relation_by_id("test-relation", 1)
+
     def test_given_relation_not_found_when_get_app_relation_data_then_raises_no_such_relation(
         self,
     ):


### PR DESCRIPTION
# Description

Implements the `JujuFacade` class and uses it in `VaultTLSManager`
This PR implements TE109.

It regroups exceptions and raises them wrapped in exceptions defined in the library.

For example `get_secret` would still raise an exception if the secret was not found, wrapped in `NoSuchSecretError` however the advantage of juju_facade is that the caller doesn't need to run `get_secret`, then `secret.get_content` and finally `set_content` to change the secret content. It is all wrapped into one call. For more info please read the spec.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
