### PR TITLE
build: Use 5.0 stable for lxd to avoid build failures on version bumps

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-          channel: 5.20/stable
+          channel: 5.0/stable
 
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
@@ -35,7 +35,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@v0.1.2
         with:
-          channel: 5.20/stable
+          channel: 5.0/stable
 
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -37,7 +37,7 @@ jobs:
           provider: microk8s
           channel: 1.29-strict/stable
           juju-channel: 3.4/stable
-          lxd-channel: 5.20/stable
+          lxd-channel: 5.0/stable
 
       - name: Enable Metallb
         run: |


### PR DESCRIPTION
Uses 5.0/stable for lxd instead of 5.x/stable to avoid build failures on version bumps.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
