### PR TITLE
Use logger, not the root logger (logging)

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -28,7 +28,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 22
+LIBPATCH = 23
 
 
 RAFT_STATE_ENDPOINT = "v1/sys/storage/raft/autopilot/state"
@@ -166,7 +166,7 @@ class VaultClient:
             #
             # hvac.exceptions.InternalServerError:
             # core: barrier reports initialized but no seal configuration found
-            logging.error("Error while checking Vault seal status: %s", e)
+            logger.error("Error while checking Vault seal status: %s", e)
             raise VaultClientError(e) from e
 
     def read(self, path: str) -> dict:
@@ -573,7 +573,7 @@ class VaultClient:
     def create_transit_key(self, mount_point: str, key_name: str) -> None:
         """Create a new key in the transit backend."""
         response = self._client.secrets.transit.create_key(mount_point=mount_point, name=key_name)
-        logging.debug("Created a new transit key. response=%s", response)
+        logger.debug("Created a new transit key. response=%s", response)
 
     def delete_role(self, name: str) -> None:
         """Delete the approle with the given name."""


### PR DESCRIPTION
This is a bad habit I have that I blame on Django.

Unfortunately, the ruff check for this is still not stable.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
