### PR TITLE
chore: bump juju and microk8s versions in CI

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -35,8 +35,8 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.29-strict/stable
-          juju-channel: 3.4/stable
+          channel: 1.31-strict/stable
+          juju-channel: 3.6/stable
           lxd-channel: 5.21/stable
 
       - name: Enable Metallb


### PR DESCRIPTION
# Description

- Bump Juju to `3.6/stable`
- Bump MicroK8s to `1.31-strict/stable`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
