### PR TITLE
refactor: Rename requests --> relations

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_autounseal.py
+++ b/lib/charms/vault_k8s/v0/vault_autounseal.py
@@ -354,22 +354,16 @@ class VaultAutounsealProvides(Object):
             },
         )
 
-    def get_outstanding_requests(self, relation_id: int | None = None) -> List[Relation]:
-        """Get the outstanding requests for the relation.
-
-        This will retrieve any vault-autounseal relations that have not yet had
-        credentials issued for them.
-        """
-        outstanding_requests: List[Relation] = []
-        requirer_requests = self.juju_facade.get_active_relations(self.relation_name, relation_id)
-        outstanding_requests = [
+    def get_relations_without_credentials(self, relation_id: int | None = None) -> List[Relation]:
+        """Get the relations which do not have credentials for auto-unseal."""
+        requirer_relations = self.juju_facade.get_active_relations(self.relation_name, relation_id)
+        return [
             relation
-            for relation in requirer_requests
-            if not self._credentials_issued_for_request(relation_id=relation.id)
+            for relation in requirer_relations
+            if not self._credentials_issued_for_relation(relation_id=relation.id)
         ]
-        return outstanding_requests
 
-    def _credentials_issued_for_request(self, relation_id: int) -> bool:
+    def _credentials_issued_for_relation(self, relation_id: int) -> bool:
         try:
             if not (
                 credentials_secret_id := self.juju_facade.get_app_relation_data(

--- a/src/charm.py
+++ b/src/charm.py
@@ -548,12 +548,14 @@ class VaultCharm(CharmBase):
             ca_cert=self.tls.pull_tls_file_from_workload(File.CA),
             mount_path=AUTOUNSEAL_MOUNT_PATH,
         )
-        outstanding_autounseal_requests = self.vault_autounseal_provides.get_outstanding_requests()
-        if outstanding_autounseal_requests:
+        relations_without_credentials = (
+            self.vault_autounseal_provides.get_relations_without_credentials()
+        )
+        if relations_without_credentials:
             vault_client.enable_secrets_engine(
                 SecretsBackend.TRANSIT, autounseal_provider_manager.mount_path
             )
-        for relation in outstanding_autounseal_requests:
+        for relation in relations_without_credentials:
             relation_address = self._get_relation_api_address(relation)
             if not relation_address:
                 logger.warning("Relation address not found for relation %s", relation.id)

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -43,8 +43,8 @@ class VaultCharmFixtures:
     patcher_pki_provider_set_relation_certificate = patch(
         "charm.TLSCertificatesProvidesV4.set_relation_certificate"
     )
-    patcher_autounseal_provides_get_outstanding_requests = patch(
-        "charm.VaultAutounsealProvides.get_outstanding_requests"
+    patcher_autounseal_provides_get_relations_without_credentials = patch(
+        "charm.VaultAutounsealProvides.get_relations_without_credentials"
     )
     patcher_autounseal_provides_set_data = patch(
         "charm.VaultAutounsealProvides.set_autounseal_data"
@@ -84,9 +84,7 @@ class VaultCharmFixtures:
         self.mock_pki_provider_set_relation_certificate = (
             VaultCharmFixtures.patcher_pki_provider_set_relation_certificate.start()
         )
-        self.mock_autounseal_provides_get_outstanding_requests = (
-            VaultCharmFixtures.patcher_autounseal_provides_get_outstanding_requests.start()
-        )
+        self.mock_autounseal_provides_get_relations_without_credentials = VaultCharmFixtures.patcher_autounseal_provides_get_relations_without_credentials.start()
         self.mock_autounseal_provides_set_data = (
             VaultCharmFixtures.patcher_autounseal_provides_set_data.start()
         )

--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_autounseal.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_autounseal.py
@@ -21,7 +21,8 @@ class VaultAutounsealProviderCharm(CharmBase):
             self.on.set_autounseal_data_action, self._on_set_autounseal_data_action
         )
         self.framework.observe(
-            self.on.get_outstanding_requests_action, self._on_get_outstanding_requests_action
+            self.on.get_relations_without_credentials_action,
+            self._on_get_relations_without_credentials_action,
         )
 
     def _on_set_autounseal_data_action(self, event: ActionEvent):
@@ -53,8 +54,8 @@ class VaultAutounsealProviderCharm(CharmBase):
             approle_secret_id=approle_secret_id,
         )
 
-    def _on_get_outstanding_requests_action(self, event: ActionEvent):
-        relations = self.interface.get_outstanding_requests()
+    def _on_get_relations_without_credentials_action(self, event: ActionEvent):
+        relations = self.interface.get_relations_without_credentials()
         event.set_results(results={"relations": [relation.id for relation in relations]})
 
 
@@ -101,8 +102,8 @@ class TestVaultAutounsealProvides:
                         },
                     },
                 },
-                "get-outstanding-requests": {
-                    "description": "Get the outstanding requests",
+                "get-relations-without-credentials": {
+                    "description": "Get any relations which do not have credentials",
                 },
             },
         )
@@ -182,16 +183,18 @@ class TestVaultAutounsealProvides:
         assert state_out.get_relation(vault_autounseal_relation.id).local_app_data == {}
         assert len(list(state_out.secrets)) == 0
 
-    def test_given_no_request_when_get_outstanding_requests_then_empty_list_is_returned(self):
+    def test_given_no_request_when_get_relations_without_credentials_then_empty_list_is_returned(
+        self,
+    ):
         state_in = testing.State(
             relations=[],
             leader=True,
         )
-        self.ctx.run(self.ctx.on.action("get-outstanding-requests"), state_in)
+        self.ctx.run(self.ctx.on.action("get-relations-without-credentials"), state_in)
         assert self.ctx.action_results
         assert self.ctx.action_results["relations"] == []
 
-    def test_given_1_outstanding_request_when_get_outstanding_requests_then_request_is_returned(
+    def test_given_1_outstanding_request_when_get_relations_without_credentials_then_request_is_returned(
         self,
     ):
         vault_autounseal_relation = testing.Relation(
@@ -203,11 +206,11 @@ class TestVaultAutounsealProvides:
             relations=[vault_autounseal_relation],
             leader=True,
         )
-        self.ctx.run(self.ctx.on.action("get-outstanding-requests"), state_in)
+        self.ctx.run(self.ctx.on.action("get-relations-without-credentials"), state_in)
         assert self.ctx.action_results
         assert self.ctx.action_results["relations"] == [vault_autounseal_relation.id]
 
-    def test_given_1_outstanding_and_1_satisfied_request_when_get_outstanding_requests_then_outstanding_request_is_returned(
+    def test_given_1_outstanding_and_1_satisfied_request_when_get_relations_without_credentials_then_outstanding_request_is_returned(
         self,
     ):
         vault_autounseal_relation_1_credentials_secret = testing.Secret(
@@ -230,11 +233,11 @@ class TestVaultAutounsealProvides:
             secrets=[vault_autounseal_relation_1_credentials_secret],
             leader=True,
         )
-        self.ctx.run(self.ctx.on.action("get-outstanding-requests"), state_in)
+        self.ctx.run(self.ctx.on.action("get-relations-without-credentials"), state_in)
         assert self.ctx.action_results
         assert self.ctx.action_results["relations"] == [vault_autounseal_relation_2.id]
 
-    def test_given_satisfied_request_when_get_outstanding_requests_then_request_is_not_returned(
+    def test_given_satisfied_request_when_get_relations_without_credentials_then_request_is_not_returned(
         self,
     ):
         vault_autounseal_relation_credentials_secret = testing.Secret(
@@ -253,11 +256,13 @@ class TestVaultAutounsealProvides:
             secrets=[vault_autounseal_relation_credentials_secret],
             leader=True,
         )
-        self.ctx.run(self.ctx.on.action("get-outstanding-requests"), state_in)
+        self.ctx.run(self.ctx.on.action("get-relations-without-credentials"), state_in)
         assert self.ctx.action_results
         assert self.ctx.action_results["relations"] == []
 
-    def test_given_2_requests_when_get_outstanding_requests_then_requests_are_returned(self):
+    def test_given_2_requests_when_get_relations_without_credentials_then_requests_are_returned(
+        self,
+    ):
         vault_autounseal_relation_1 = testing.Relation(
             endpoint="vault-autounseal-provides",
             interface="vault-autounseal",
@@ -270,7 +275,7 @@ class TestVaultAutounsealProvides:
             relations=[vault_autounseal_relation_1, vault_autounseal_relation_2],
             leader=True,
         )
-        self.ctx.run(self.ctx.on.action("get-outstanding-requests"), state_in)
+        self.ctx.run(self.ctx.on.action("get-relations-without-credentials"), state_in)
         assert self.ctx.action_results
         assert set(self.ctx.action_results["relations"]) == {
             vault_autounseal_relation_1.id,

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -441,7 +441,9 @@ class TestCharmConfigure(VaultCharmFixtures):
                 ingress_address="myhostname",
             )
             relation = MockRelation(id=vault_autounseal_relation.id)
-            self.mock_autounseal_provides_get_outstanding_requests.return_value = [relation]
+            self.mock_autounseal_provides_get_relations_without_credentials.return_value = [
+                relation
+            ]
             approle_secret = testing.Secret(
                 label="vault-approle-auth-details",
                 tracked_content={"role-id": "role id", "secret-id": "secret id"},


### PR DESCRIPTION
Addressing https://github.com/canonical/vault-operator/pull/333#discussion_r1867994211

Renames `get_outstanding_requests` (and associated code) to `get_relations_without_credentials`. This code is for detecting which auto-unseal relations still need credentials generated for them, so the new name should be easier to follow.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
