### PR TITLE
chore: Ignore all libs that must be copied for the integration tests to run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ __pycache__/
 .vscode
 
 *.pem
-tests/integration/vault_kv_requirer_operator/lib/charms/vault_k8s/v0/vault_kv.py
+tests/integration/vault_kv_requirer_operator/lib/charms/vault_k8s/v0/*
 .charm_tracing_buffer.raw


### PR DESCRIPTION
There is a new library that must be copied for the integration tests, so the gitignore is modified to capture anything in the directory.

This ensures the file isn't accidentally committed after running the integration tests locally.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
