### PR TITLE
fix: Check if the workload is accessible before running hook

### DIFF
--- a/src/container.py
+++ b/src/container.py
@@ -51,3 +51,7 @@ class Container(WorkloadBase):
     def stop(self, process: str) -> None:
         """Stop the workload."""
         self._container.stop(process)
+
+    def is_accessible(self) -> bool:
+        """Check if we can connect to pebble."""
+        return self._container.can_connect()


### PR DESCRIPTION
This ensures that pebble is accessible before running the hook, otherwise we could get a pebble error when trying to do something like access the certificate in the workload.

This issue is currently causing plenty of integration test failures. This change appears to fix that.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
