### PR TITLE
refactor: Remove "Vault" from the beginning of Vault Managers.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -56,11 +56,11 @@ from charms.vault_k8s.v0.vault_kv import (
 )
 from charms.vault_k8s.v0.vault_managers import (
     AutounsealConfigurationDetails,
+    AutounsealProviderManager,
+    AutounsealRequirerManager,
     File,
-    VaultAutounsealProviderManager,
-    VaultAutounsealRequirerManager,
+    TLSManager,
     VaultCertsError,
-    VaultTLSManager,
 )
 from charms.vault_k8s.v0.vault_s3 import S3, S3Error
 from jinja2 import Environment, FileSystemLoader
@@ -169,7 +169,7 @@ class VaultCharm(CharmBase):
             charm=self,
             relation_name=LOG_FORWARDING_RELATION_NAME,
         )
-        self.tls = VaultTLSManager(
+        self.tls = TLSManager(
             charm=self,
             workload=self._container,
             service_name=self._container_name,
@@ -531,7 +531,7 @@ class VaultCharm(CharmBase):
         if not self.unit.is_leader():
             logger.debug("Only leader unit can handle a vault-autounseal request")
             return
-        autounseal_provider_manager = VaultAutounsealProviderManager(
+        autounseal_provider_manager = AutounsealProviderManager(
             charm=self,
             client=vault_client,
             provides=self.vault_autounseal_provides,
@@ -1069,7 +1069,7 @@ class VaultCharm(CharmBase):
         autounseal_relation_details = self.vault_autounseal_requires.get_details()
         if not autounseal_relation_details:
             return None
-        autounseal_requirer_manager = VaultAutounsealRequirerManager(
+        autounseal_requirer_manager = AutounsealRequirerManager(
             self, self.vault_autounseal_requires
         )
         self.tls.push_autounseal_ca_cert(autounseal_relation_details.ca_certificate)

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -10,9 +10,9 @@ from charms.vault_k8s.v0.vault_client import (
     VaultClient,
 )
 from charms.vault_k8s.v0.vault_managers import (
-    VaultAutounsealProviderManager,
-    VaultAutounsealRequirerManager,
-    VaultTLSManager,
+    AutounsealProviderManager,
+    AutounsealRequirerManager,
+    TLSManager,
 )
 from charms.vault_k8s.v0.vault_s3 import S3
 
@@ -20,13 +20,13 @@ from charm import VaultCharm
 
 
 class VaultCharmFixtures:
-    patcher_tls = patch("charm.VaultTLSManager", autospec=VaultTLSManager)
+    patcher_tls = patch("charm.TLSManager", autospec=TLSManager)
     patcher_vault = patch("charm.VaultClient", autospec=VaultClient)
     patcher_vault_autounseal_provider_manager = patch(
-        "charm.VaultAutounsealProviderManager", autospec=VaultAutounsealProviderManager
+        "charm.AutounsealProviderManager", autospec=AutounsealProviderManager
     )
     patcher_vault_autounseal_requirer_manager = patch(
-        "charm.VaultAutounsealRequirerManager", autospec=VaultAutounsealRequirerManager
+        "charm.AutounsealRequirerManager", autospec=AutounsealRequirerManager
     )
     patcher_s3_requirer = patch("charm.S3Requirer", autospec=S3Requirer)
     patcher_s3 = patch("charm.S3", autospec=S3)

--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_managers.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_managers.py
@@ -6,14 +6,14 @@ from charms.vault_k8s.v0.vault_autounseal import AutounsealDetails
 from charms.vault_k8s.v0.vault_client import AuthMethod, VaultClient
 from charms.vault_k8s.v0.vault_managers import (
     AUTOUNSEAL_POLICY,
-    VaultAutounsealProviderManager,
-    VaultAutounsealRequirerManager,
+    AutounsealProviderManager,
+    AutounsealRequirerManager,
 )
 
 from charm import AUTOUNSEAL_MOUNT_PATH
 
 
-class TestVaultAutounsealRequirerManager:
+class TestAutounsealRequirerManager:
     @pytest.mark.parametrize(
         "token, token_valid, expected_token",
         [
@@ -59,12 +59,12 @@ class TestVaultAutounsealRequirerManager:
         if not token:
             juju_facade_instance.get_secret_content_values.side_effect = SecretRemovedError()
 
-        autounseal = VaultAutounsealRequirerManager(charm, requires)
+        autounseal = AutounsealRequirerManager(charm, requires)
         returned_token = autounseal.get_provider_vault_token(autounseal_details, ca_cert_path)
         assert returned_token == expected_token
 
 
-class TestVaultAutounsealProviderManager:
+class TestAutounsealProviderManager:
     def test_when_create_credentials_then_vault_client_called_and_key_name_and_credentials_are_returned(
         self,
     ):
@@ -80,7 +80,7 @@ class TestVaultAutounsealProviderManager:
         vault_client.create_or_update_approle.return_value = "role_id"
         vault_client.generate_role_secret_id.return_value = "secret_id"
 
-        autounseal = VaultAutounsealProviderManager(
+        autounseal = AutounsealProviderManager(
             charm, vault_client, provides, "ca_cert", AUTOUNSEAL_MOUNT_PATH
         )
 
@@ -115,7 +115,7 @@ class TestVaultAutounsealProviderManager:
         test_relation.id = 123
         provides.get_outstanding_requests.return_value = [test_relation]
         juju_facade_instance.get_active_relations.return_value = [test_relation]
-        autounseal = VaultAutounsealProviderManager(
+        autounseal = AutounsealProviderManager(
             charm, vault_client_mock, provides, "ca_cert", AUTOUNSEAL_MOUNT_PATH
         )
 


### PR DESCRIPTION
Since these all come from a module named vault_managers, it is  redundant to prefix these.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of any required library.
