### PR TITLE
fix: retry authorize-charm

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1198,13 +1198,13 @@ async def authorize_charm(
     secret = await ops_test.model.add_secret(f"approle-token-{app_name}", [f"token={root_token}"])
     secret_id = secret.split(":")[-1]
     await ops_test.model.grant_secret(f"approle-token-{app_name}", app_name)
-    authorize_action = await leader_unit.run_action(
-        action_name="authorize-charm",
-        **{
-            "secret-id": secret_id,
-        },
-    )
     for _ in range(attempts):
+        authorize_action = await leader_unit.run_action(
+            action_name="authorize-charm",
+            **{
+                "secret-id": secret_id,
+            },
+        )
         result = await ops_test.model.get_action_output(
             action_uuid=authorize_action.entity_id, wait=120
         )


### PR DESCRIPTION
I believe this was the original intention of #567 

This change retries the action itself. The current code just retries retrieving the action output, but only runs the action once.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
