### PR TITLE
fix: Make sure pebble layer is applied before restarting

### DIFF
--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -52,6 +52,7 @@ class VaultCharmFixtures:
     patcher_autounseal_requires_get_details = patch("charm.VaultAutounsealRequires.get_details")
     patcher_kv_provides_get_credentials = patch("charm.VaultKvProvides.get_credentials")
     patcher_kv_provides_set_kv_data = patch("charm.VaultKvProvides.set_kv_data")
+    patcher_pebble_layer_is_applied = patch("charm.VaultCharm._pebble_layer_is_applied")
     patcher_get_binding = patch("ops.model.Model.get_binding")
 
     @pytest.fixture(autouse=True)
@@ -95,6 +96,9 @@ class VaultCharmFixtures:
         self.mock_get_binding = VaultCharmFixtures.patcher_get_binding.start()
         self.mock_pki_requirer_renew_certificate = (
             VaultCharmFixtures.patcher_pki_requirer_renew_certificate.start()
+        )
+        self.mock_pebble_layer_is_applied = (
+            VaultCharmFixtures.patcher_pebble_layer_is_applied.start()
         )
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
# Description

**This is draft | Not ready for review**: There is more into this PR trying to figure out why would the restart be attempted in the first place.


Turns out the intermittent integration test error
```
- Start service "vault" (service start attempt: exited quickly with code 1, will restart)
----- Logs from task 1 -----
2024-12-18T14:26:23Z INFO Most recent service output:
    error loading configuration from /vault/config/config.hcl: stat /vault/config/config.hcl: no such file or directory
    error loading configuration from /vault/config/config.hcl: stat /vault/config/config.hcl: no such file or directory
2024-12-18T14:26:23Z ERROR service start attempt: exited quickly with code 1, will restart
-----
```
Is not caused by the file not being properly copied, but by trying to "restart" the service before the pebble plan being applied, this explains why vault is looking for the config on the default path.

This still wierd since we check if `_vault_service_is_running()` before restarting.

In this PR we double check the pebble layer before generating the config and therefore potentially restarting the service.



# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
