### PR TITLE
fix: Use uv sync in tox to use locked versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ lib_path = {toxinidir}/lib/charms/vault_k8s/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path} {[vars]lib_path}
 
 [testenv]
+runner = uv-venv-lock-runner
+with_dev = true
 set_env =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}:{[vars]integration_test_path}/vault_kv_requirer_operator/src
     PYTHONBREAKPOINT=pdb.set_trace


### PR DESCRIPTION
# Description

Use uv sync in tox to use locked versions. This ensures that tox will not install newer packages when running.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
