### PR TITLE
fix: remove CIDR from approle

### DIFF
--- a/tests/unit/test_charm_authorize_action.py
+++ b/tests/unit/test_charm_authorize_action.py
@@ -178,7 +178,6 @@ class TestCharmAuthorizeAction(VaultCharmFixtures):
         )
         self.mock_vault.create_or_update_approle.assert_called_once_with(
             name="charm",
-            cidrs=["1.2.3.4/24"],
             policies=["charm-access", "default"],
             token_ttl="1h",
             token_max_ttl="1h",

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -39,28 +39,6 @@ class TestCharmCollectUnitStatus(VaultCharmFixtures):
 
         assert state_out.unit_status == WaitingStatus("Waiting for peer relation")
 
-    def test_given_bind_address_not_available_when_collect_unit_status_then_status_is_waiting(
-        self,
-    ):
-        container = testing.Container(
-            name="vault",
-            can_connect=True,
-        )
-        peer_relation = testing.PeerRelation(
-            endpoint="vault-peers",
-        )
-        self.mock_get_binding.return_value = None
-        state_in = testing.State(
-            containers=[container],
-            relations=[peer_relation],
-        )
-
-        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
-
-        assert state_out.unit_status == WaitingStatus(
-            "Waiting for bind and ingress addresses to be available"
-        )
-
     def test_ca_not_available_when_collect_unit_status_then_status_is_waiting(
         self,
     ):


### PR DESCRIPTION
# Description

We were creating an approle that would expect its user to be in a /24 subnet defined by the leader's bind address.  However, there is no guarantee that different charm units will have bind addresses in the same /24 subnet.  This behavior caused a bug in non /24 subnet, and would also cause issues if/when units are in different subnets alltogether.  Here we are simply removing any IP requirement from the approle. 

Fixes #582 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
