### PR TITLE
feat: Allow bootstrapping raft via an action

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -151,6 +151,14 @@ actions:
           stored by the charm.
     required: [secret-id] 
 
+  bootstrap-raft:
+    description: >-
+      Bootstraps raft using a peers.json file. This action requires the
+      application to first be scaled to a single unit.  Bootstrapping can help
+      recover when quorum is lost, however, it may cause uncommitted Raft log
+      entries to be committed. See
+      https://developer.hashicorp.com/vault/docs/concepts/integrated-storage#manual-recovery-using-peers-json
+      for more details.
   create-backup:
     description: >-
       Creates a snapshot of the Raft backend and saves it to the S3 storage.

--- a/lib/charms/vault_k8s/v0/juju_facade.py
+++ b/lib/charms/vault_k8s/v0/juju_facade.py
@@ -27,7 +27,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 logger = logging.getLogger(__name__)
 
@@ -720,3 +720,8 @@ class JujuFacade:
     def is_leader(self) -> bool:
         """Check if the unit is leader."""
         return self.charm.unit.is_leader()
+
+    @property
+    def planned_units_for_app(self) -> int:
+        """Return the number of planned units for the application."""
+        return self.charm.app.planned_units()

--- a/lib/charms/vault_k8s/v0/vault_managers.py
+++ b/lib/charms/vault_k8s/v0/vault_managers.py
@@ -1479,12 +1479,12 @@ class RaftManager:
             raise ManagerError("Bootstrapping a Vault cluster requires exactly one unit")
 
         self._workload.stop(self._service_name)
-        self._create_peers_json(node_id, address)
+        self._push_peers_json(node_id, address)
         self._workload.restart(self._service_name)
 
         logger.info("Vault cluster bootstrapped in Raft mode")
 
-    def _create_peers_json(self, node_id: str, address: str) -> None:
+    def _push_peers_json(self, node_id: str, address: str) -> None:
         """Create the peers.json file for the Vault cluster.
 
         This method will create the peers.json file for the Vault cluster based

--- a/src/charm.py
+++ b/src/charm.py
@@ -61,6 +61,7 @@ from charms.vault_k8s.v0.vault_managers import (
     KVManager,
     ManagerError,
     PKIManager,
+    RaftManager,
     TLSManager,
     VaultCertsError,
 )
@@ -208,6 +209,7 @@ class VaultCharm(CharmBase):
         self.framework.observe(self.on.create_backup_action, self._on_create_backup_action)
         self.framework.observe(self.on.list_backups_action, self._on_list_backups_action)
         self.framework.observe(self.on.restore_backup_action, self._on_restore_backup_action)
+        self.framework.observe(self.on.bootstrap_raft_action, self._on_bootstrap_raft_action)
         self.framework.observe(
             self.vault_kv.on.vault_kv_client_detached, self._on_vault_kv_client_detached
         )
@@ -516,6 +518,21 @@ class VaultCharm(CharmBase):
         except VaultClientError as e:
             logger.exception("Vault returned an error while authorizing the charm")
             event.fail(f"Vault returned an error while authorizing the charm: {str(e)}")
+
+    def _on_bootstrap_raft_action(self, event: ActionEvent) -> None:
+        """Bootstraps the raft cluster when a single node is present.
+
+        This is useful when Vault has lost quorum. The application must first
+        be reduced to a single unit.
+        """
+        try:
+            manager = RaftManager(self, self._container, self._service_name, VAULT_STORAGE_PATH)
+            manager.bootstrap(self._node_id, self._api_address)
+        except ManagerError as e:
+            logger.error("Failed to bootstrap raft: %s", e)
+            event.fail(message=f"Failed to bootstrap raft: {e}")
+            return
+        event.set_results({"result": "Raft cluster bootstrapped successfully."})
 
     def _on_create_backup_action(self, event: ActionEvent) -> None:
         """Handle the create-backup action.


### PR DESCRIPTION
Implements bootstrapping raft via an action as per TE133.

The user experience is as follows:

```
juju scale-application 1
juju run vault/leader bootstrap-raft
juju scale-application 5
```

Cleanup of the `peers.json` file is done automatically by Vault once the single-unit cluster recovers.

CharmHub docs to follow in a separate task.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of any required library.
