### PR TITLE
fix: Handle when retry-joins don't exist in the config

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_helpers.py
+++ b/lib/charms/vault_k8s/v0/vault_helpers.py
@@ -15,7 +15,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +98,11 @@ def config_file_content_matches(existing_content: str, new_content: str) -> bool
         return existing_config_hcl == new_content_hcl
 
     new_retry_joins = new_content_hcl["storage"]["raft"].pop("retry_join", [])
-    existing_retry_joins = existing_config_hcl["storage"]["raft"].pop("retry_join", [])
+
+    try:
+        existing_retry_joins = existing_config_hcl["storage"]["raft"].pop("retry_join", [])
+    except KeyError:
+        existing_retry_joins = []
 
     # If there is only one retry join, it is a dict
     if isinstance(new_retry_joins, dict):


### PR DESCRIPTION
# Description

This change was introduced in the machine charm to handle the case when retry joins are not present in the config. We include this check in the lib.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of any required library.
