### PR TITLE
feat: Provide the Vault token via an env var

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_helpers.py
+++ b/lib/charms/vault_k8s/v0/vault_helpers.py
@@ -1,10 +1,10 @@
 """This library contains helper function used when configuring the Vault service."""
 
 import logging
+from dataclasses import dataclass
 from typing import Dict, List
 
 import hcl
-from charms.vault_k8s.v0.vault_managers import AutounsealConfigurationDetails
 from jinja2 import Environment, FileSystemLoader
 
 # The unique Charmhub library identifier, never change it
@@ -15,9 +15,19 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AutounsealConfiguration:
+    """Details required for configuring auto-unseal on Vault."""
+
+    address: str
+    mount_path: str
+    key_name: str
+    ca_cert_path: str
 
 
 def common_name_config_is_valid(common_name: str) -> bool:
@@ -38,7 +48,7 @@ def render_vault_config_file(
     raft_storage_path: str,
     node_id: str,
     retry_joins: List[Dict[str, str]],
-    autounseal_details: AutounsealConfigurationDetails | None = None,
+    autounseal_config: AutounsealConfiguration | None = None,
 ) -> str:
     """Render the Vault config file."""
     jinja2_environment = Environment(loader=FileSystemLoader(config_template_path))
@@ -54,11 +64,10 @@ def render_vault_config_file(
         raft_storage_path=raft_storage_path,
         node_id=node_id,
         retry_joins=retry_joins,
-        autounseal_address=autounseal_details.address if autounseal_details else None,
-        autounseal_key_name=autounseal_details.key_name if autounseal_details else None,
-        autounseal_mount_path=autounseal_details.mount_path if autounseal_details else None,
-        autounseal_token=autounseal_details.token if autounseal_details else None,
-        autounseal_tls_ca_cert=autounseal_details.ca_cert_path if autounseal_details else None,
+        autounseal_address=autounseal_config.address if autounseal_config else None,
+        autounseal_mount_path=autounseal_config.mount_path if autounseal_config else None,
+        autounseal_key_name=autounseal_config.key_name if autounseal_config else None,
+        autounseal_ca_cert_path=autounseal_config.ca_cert_path if autounseal_config else None,
     )
     return content
 

--- a/lib/charms/vault_k8s/v0/vault_managers.py
+++ b/lib/charms/vault_k8s/v0/vault_managers.py
@@ -32,7 +32,6 @@ import json
 import logging
 import os
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum, auto
 from typing import FrozenSet, MutableMapping, TextIO
@@ -87,7 +86,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 SEND_CA_CERT_RELATION_NAME = "send-ca-cert"
@@ -805,17 +804,6 @@ class AutounsealProviderManager:
     def _get_existing_policies(self) -> list[str]:
         output = self._client.list("sys/policy")
         return [policy for policy in output if policy.startswith(Naming.autounseal_policy_prefix)]
-
-
-@dataclass
-class AutounsealConfigurationDetails:
-    """Credentials required for configuring auto-unseal on Vault."""
-
-    address: str
-    mount_path: str
-    key_name: str
-    token: str
-    ca_cert_path: str
 
 
 class AutounsealRequirerManager:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,5 +91,5 @@ max-complexity = 10
 skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 
 [tool.pyright]
-include = ["src/**.py"]
+include = ["src/", "lib/charms/vault_k8s/"]
 reportMissingParameterType = true

--- a/src/templates/vault.hcl.j2
+++ b/src/templates/vault.hcl.j2
@@ -32,7 +32,6 @@ seal "transit" {
   disable_renewal = "false"
   key_name        = "{{ autounseal_key_name }}"
   mount_path      = "{{ autounseal_mount_path }}"
-  token           = "{{ autounseal_token }}"
-  tls_ca_cert     = "{{ autounseal_tls_ca_cert }}"
+  tls_ca_cert     = "{{ autounseal_ca_cert_path }}"
 }
 {% endif %}


### PR DESCRIPTION
This change provides the vault token via an environment variable, [as recommended by the docs](https://developer.hashicorp.com/vault/docs/configuration/seal/transit#authentication). This avoids writing the token to disk, which has security implications.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of any required library.
