### PR TITLE
fix: Remove sans_ip extension from Vault certs

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -175,7 +175,6 @@ class VaultCharm(CharmBase):
             tls_directory_path=CONTAINER_TLS_FILE_DIRECTORY_PATH,
             common_name=self._ingress_address if self._ingress_address else "",
             sans_dns=frozenset([socket.getfqdn()]),
-            sans_ip=frozenset([self._ingress_address] if self._ingress_address else []),
         )
         self.ingress = IngressPerAppRequirer(
             charm=self,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -230,6 +230,7 @@ class TestVaultK8s:
             wait_for_exact_units=NUM_VAULT_UNITS,
         )
 
+        unit_addresses = [row.get("address") for row in await read_vault_unit_statuses(ops_test)]
         client = hvac.Client(url=f"https://{unit_addresses[0]}:8200", verify=False)
         client.token = root_token
         response = client.sys.read_raft_config()

--- a/tests/unit/lib/charms/vault_k8s/v0/test_vault_tls.py
+++ b/tests/unit/lib/charms/vault_k8s/v0/test_vault_tls.py
@@ -208,7 +208,6 @@ class TestCharmTLS:
                 certificate_request=CertificateRequestAttributes(
                     common_name=ingress_address,
                     sans_dns=frozenset({self.fqdn}),
-                    sans_ip=frozenset({ingress_address}),
                     sans_oid=frozenset(),
                     email_address=None,
                     organization=None,

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -6,6 +6,7 @@
 import tempfile
 from datetime import timedelta
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import hcl
 import ops.testing as testing
@@ -322,6 +323,7 @@ class TestCharmConfigure(VaultCharmFixtures):
 
     # Test KV
 
+    @patch("socket.getfqdn", new=MagicMock(return_value="vault"))
     def test_given_kv_request_when_configure_then_generate_credentials_for_requirer_is_called(
         self,
     ):


### PR DESCRIPTION
# Description

This applies the changes proposed in spec TE089 to remove the sans_ip extension from the certificates of Vault.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of any required library.
