### PR TITLE
fix: Get addresses before creating the Vault client

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -230,6 +230,7 @@ class TestVaultK8s:
             wait_for_exact_units=NUM_VAULT_UNITS,
         )
 
+        unit_addresses = [row.get("address") for row in await read_vault_unit_statuses(ops_test)]
         client = hvac.Client(url=f"https://{unit_addresses[0]}:8200", verify=False)
         client.token = root_token
         response = client.sys.read_raft_config()


### PR DESCRIPTION
# Description

After scaling up we get the addresses again before creating the Vault client.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
