### PR TITLE
fix: point to charm directory

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,11 +60,11 @@ jobs:
       - k8s-static-analysis
       - k8s-unit-tests-with-coverage
       - k8s-integration-test
-    if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release-') }}
-    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm.yaml@v0
+    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm.yaml@dev-publish-path
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
     with:
+      path: ./k8s/
       track-name: 1.16
       artifact-name: built-k8s-charm
 
@@ -118,9 +118,10 @@ jobs:
       - machine-unit-tests-with-coverage
       - machine-integration-test
     if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release-') }}
-    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm.yaml@v0
+    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm.yaml@dev-publish-path
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
     with:
+      path: ./machine/
       track-name: 1.16
       artifact-name: built-machine-charm

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,7 +60,8 @@ jobs:
       - k8s-static-analysis
       - k8s-unit-tests-with-coverage
       - k8s-integration-test
-    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm.yaml@dev-publish-path
+    if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release-') }}
+    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm.yaml@v0
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
     with:
@@ -118,7 +119,7 @@ jobs:
       - machine-unit-tests-with-coverage
       - machine-integration-test
     if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release-') }}
-    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm.yaml@dev-publish-path
+    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm.yaml@v0
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
     with:

--- a/machine/CONTRIBUTING.md
+++ b/machine/CONTRIBUTING.md
@@ -17,8 +17,7 @@ source .venv/bin/activate
 
 ## Testing
 
-This project uses `tox` for managing test environments. It can be installed
-with:
+This project uses `tox` for managing test environments. It can be installed with:
 
 ```shell
 uv tool install tox --with tox-uv


### PR DESCRIPTION
# Description

Charm publishing is now broken on `main`.  The upload-charm github action uses the `charmcraft.yaml` file to figure out the resource to be uploaded. Here we point to the right charm directory to allow the workflow to function.

To do before merging:
- [x] Merge workflow change:
  - https://github.com/canonical/identity-credentials-workflows/pull/18

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
