### PR TITLE
fix: charm selection in promote action

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -10,6 +10,12 @@ on:
           - edge -> beta
           - beta -> candidate
           - candidate -> stable
+      charm:
+        type: choice
+        description: Charm to promote
+        options:
+          - k8s
+          - machine
 
 jobs:
   promote:
@@ -35,6 +41,7 @@ jobs:
       - name: Promote Charm
         uses: canonical/charming-actions/release-charm@2.7.0
         with:
+          charm-path: ./${{ github.event.inputs.charm }}
           base-channel: 22.04
           credentials: ${{ secrets.CHARMCRAFT_AUTH }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

Here we apply the same change as in #618 , in the `release-1.16` branch.

---

Unless a charm-path is provided, the release action assumes the charm path is the current working directory. Since we are working in a repo with multiple charms, we must now provide the charm path and let users select which charm to promote via a new charm action input parameters.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
