### PR TITLE
fix: update libs for individual charms

### DIFF
--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -30,10 +30,21 @@ jobs:
           git config --global user.signingkey ~/.ssh/id_rsa.pub
           git config --global commit.gpgsign true
           git config --global gpg.format ssh
-
-      - name: Fetch charm libraries
+      
+      - name: Install charmcraft
         run: |
           sudo snap install charmcraft --classic --channel latest/stable
+
+      - name: Fetch charm libraries (k8s)
+        run: |
+          cd k8s
+          charmcraft fetch-lib
+        env:
+          CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"
+      
+      - name: Fetch charm libraries (machine)
+        run: |
+          cd machine
           charmcraft fetch-lib
         env:
           CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"


### PR DESCRIPTION
# Description

Since we merged the repos, the update-libs workflow wouldn't work because the charm directories are not in the project's root anymore. Here we go to the charm's directory before fetching the libs.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
