### PR TITLE
build: add TICS static analysis workflow

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -1,0 +1,12 @@
+name: TICS Static Analysis
+
+on:
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  analyze:
+    # this workflow doesn't exist yet, but including this file will allow me to test with the `workflow_dispatch` event
+    uses: canonical/identity-credentials-workflows/.github/workflows/tics-charm.yaml@v0
+    secrets:
+      TICSAUTHTOKEN: ${{ secrets.TICSAUTHTOKEN }}
+


### PR DESCRIPTION
Currently, this workflow will instantly fail because the upstream one doesn't exist yet, however, including this workflow file in the main branch will allow me to test the workflow and upstream workflow using `workflow_dispatch` on a development branch.

I'd like to be able to run here so I can try working in a repo with multiple charms.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
