### PR TITLE
feat: add terraform modules for operating Vault

### DIFF
--- a/k8s/terraform/README.md
+++ b/k8s/terraform/README.md
@@ -6,14 +6,9 @@ The module uses the [Terraform Juju provider][Terraform Juju provider] to model 
 
 The base module is not intended to be deployed in separation (it is possible though), but should rather serve as a building block for higher level modules.
 
-## Module structure
+## Getting Started
 
-- **main.tf** - Defines the Juju application to be deployed.
-- **variables.tf** - Allows customization of the deployment. Except for exposing the deployment options (Juju model name, channel or application name) also models the charm configuration.
-- **output.tf** - Responsible for integrating the module with other Terraform modules, primarily by defining potential integration endpoints (charm integrations), but also by exposing the application name.
-- **versions.tf** - Defines the Terraform provider.
-
-## Pre-requisites
+**Pre-requisites**
 
 The following tools needs to be installed and should be running in the environment. Please [set up your environment][set-up-environment] before deployment.
 
@@ -22,37 +17,88 @@ The following tools needs to be installed and should be running in the environme
 - Juju controller bootstrapped onto the K8s cluster
 - Terraform
 
-## Using vault-k8s base module in higher level modules
+On the host machine create a new directory called terraform:
 
-If you want to use `vault-k8s` base module as part of your Terraform module, import it like shown below.
-
-```text
-module "vault-k8s {
-  source = "git::https://github.com/canonical/vault-k8s-operator/k8s//terraform"
-  
-  model = "juju_model_name"
-  (Customize configuration variables here if needed)
-}
+```shell
+mkdir terraform
 ```
 
-Create the integrations, for instance:
+Inside newly created terraform directory create a versions.tf file:
+
+```shell
+cd terraform
+cat << EOF > versions.tf
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.12.0"
+    }
+  }
+}
+EOF
+```
+
+Create a Terraform module containing Vault K8s:
+
+```shell
+cat << EOF > main.tf
+resource "juju_model" "demo" {
+  name = "demo"
+}
+
+module "vault-k8s" {
+  source = "git::https://github.com/canonical/vault-k8s-operator//k8s/terraform"
+  
+  model = "demo"
+}
+EOF
+```
+
+Initialize Juju Terraform provider:
+
+```shell
+terraform init
+```
+
+Deploy the module:
+
+```shell
+terraform apply
+```
+
+## How-to
+
+### Create integrations
+
+Add the following content to your module's `main.tf` file to create the integration between the `vault-k8s` charm and other charms.
 
 ```text
-resource "juju_integration" "certificates-endpoint-integration" {
+resource "juju_integration" "vault-kv-integration" {
   model = var.model
 
   application {
     name     = module.some-app.app_name
-    endpoint = module.some-app.certificates_endpoint
+    endpoint = module.some-app.vault-kv
   }
 
   application {
     name     = module.vault-k8s.app_name
-    endpoint = module.vault-k8s.provides.certificates
+    endpoint = module.vault-k8s.provides.vault-kv
   }
 }
 ```
 
+## Reference
+
+## Module structure
+
+- **main.tf** - Defines the Juju application to be deployed.
+- **variables.tf** - Allows customization of the deployment. Except for exposing the deployment options (Juju model name, channel or application name) also models the charm configuration.
+- **output.tf** - Responsible for integrating the module with other Terraform modules, primarily by defining potential integration endpoints (charm integrations), but also by exposing the application name.
+- **versions.tf** - Defines the Terraform provider.
+
+## Useful links
 
 [Terraform]: https://www.terraform.io/
 [Terraform Juju provider]: https://registry.terraform.io/providers/juju/juju/latest

--- a/k8s/terraform/README.md
+++ b/k8s/terraform/README.md
@@ -52,7 +52,7 @@ resource "juju_model" "demo" {
 module "vault-k8s" {
   source = "git::https://github.com/canonical/vault-k8s-operator//k8s/terraform"
   
-  model = "demo"
+  model      = juju_model.demo.name
 }
 EOF
 ```

--- a/k8s/terraform/README.md
+++ b/k8s/terraform/README.md
@@ -8,7 +8,7 @@ The base module is not intended to be deployed in separation (it is possible tho
 
 ## Getting Started
 
-**Pre-requisites**
+### Pre-requisites
 
 The following tools needs to be installed and should be running in the environment. Please [set up your environment][set-up-environment] before deployment.
 
@@ -16,6 +16,8 @@ The following tools needs to be installed and should be running in the environme
 - Juju
 - Juju controller bootstrapped onto the K8s cluster
 - Terraform
+
+### Deploying Vault K8s
 
 On the host machine create a new directory called terraform:
 
@@ -97,8 +99,6 @@ resource "juju_integration" "vault-kv-integration" {
 - **variables.tf** - Allows customization of the deployment. Except for exposing the deployment options (Juju model name, channel or application name) also models the charm configuration.
 - **output.tf** - Responsible for integrating the module with other Terraform modules, primarily by defining potential integration endpoints (charm integrations), but also by exposing the application name.
 - **versions.tf** - Defines the Terraform provider.
-
-## Useful links
 
 [Terraform]: https://www.terraform.io/
 [Terraform Juju provider]: https://registry.terraform.io/providers/juju/juju/latest

--- a/k8s/terraform/README.md
+++ b/k8s/terraform/README.md
@@ -1,0 +1,61 @@
+# Vault K8s Terraform module
+
+This folder contains a base [Terraform][Terraform] module for the `vault-k8s` charm.
+
+The module uses the [Terraform Juju provider][Terraform Juju provider] to model the charm deployment onto any Kubernetes environment managed by [Juju][Juju].
+
+The base module is not intended to be deployed in separation (it is possible though), but should rather serve as a building block for higher level modules.
+
+## Module structure
+
+- **main.tf** - Defines the Juju application to be deployed.
+- **variables.tf** - Allows customization of the deployment. Except for exposing the deployment options (Juju model name, channel or application name) also models the charm configuration.
+- **output.tf** - Responsible for integrating the module with other Terraform modules, primarily by defining potential integration endpoints (charm integrations), but also by exposing the application name.
+- **versions.tf** - Defines the Terraform provider.
+
+## Pre-requisites
+
+The following tools needs to be installed and should be running in the environment. Please [set up your environment][set-up-environment] before deployment.
+
+- A Kubernetes cluster
+- Juju
+- Juju controller bootstrapped onto the K8s cluster
+- Terraform
+
+## Using vault-k8s base module in higher level modules
+
+If you want to use `vault-k8s` base module as part of your Terraform module, import it like shown below.
+
+```text
+module "vault-k8s {
+  source = "git::https://github.com/canonical/vault-k8s-operator/k8s//terraform"
+  
+  model = "juju_model_name"
+  (Customize configuration variables here if needed)
+}
+```
+
+Create the integrations, for instance:
+
+```text
+resource "juju_integration" "certificates-endpoint-integration" {
+  model = var.model
+
+  application {
+    name     = module.some-app.app_name
+    endpoint = module.some-app.certificates_endpoint
+  }
+
+  application {
+    name     = module.vault-k8s.app_name
+    endpoint = module.vault-k8s.provides.certificates
+  }
+}
+```
+
+
+[Terraform]: https://www.terraform.io/
+[Terraform Juju provider]: https://registry.terraform.io/providers/juju/juju/latest
+[Juju]: https://juju.is
+[vault-k8s-integrations]: https://charmhub.io/vault-k8s/integrations
+[set-up-environment]: [https://discourse.charmhub.io/t/set-up-your-development-environment-with-microk8s-for-juju-terraform-provider/13109#prepare-development-environment-2]

--- a/k8s/terraform/README.md
+++ b/k8s/terraform/README.md
@@ -32,7 +32,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.12.0"
+      version = "~= 0.18.0"
     }
   }
 }

--- a/k8s/terraform/main.tf
+++ b/k8s/terraform/main.tf
@@ -1,0 +1,18 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "vault-k8s" {
+  name  = var.app_name
+  model = var.model
+
+  charm {
+    name     = "vault-k8s"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  units       = var.units
+}

--- a/k8s/terraform/outputs.tf
+++ b/k8s/terraform/outputs.tf
@@ -1,0 +1,31 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.vault-k8s.name
+}
+
+output "requires" {
+  value = {
+    vault-autounseal-requires = "vault-autounseal-requires"
+    ingress                   = "ingress"
+    ingress-per-unit          = "ingress-per-unit"
+    tls-certificates-access   = "tls-certificates-access"
+    tls-certificates-pki      = "tls-certificates-pki"
+    logging                   = "logging"
+    s3-parameters             = "s3-parameters"
+    tracing                   = "tracing"
+  }
+}
+
+output "provides" {
+  value = {
+    vault-autounseal-provides = "vault-autounseal-provides"
+    vault-kv                  = "vault-kv"
+    vault-pki                 = "vault-pki"
+    metrics-endpoint          = "metrics-endpoint"
+    send-ca-cert              = "send-ca-cert"
+    grafana-dashboard         = "grafana-dashboard"
+  }
+}

--- a/k8s/terraform/variables.tf
+++ b/k8s/terraform/variables.tf
@@ -1,0 +1,56 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "vault-k8s"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying a charm."
+  type        = string
+  default     = "beta"
+}
+
+variable "config" {
+  description = "Application config. Details about available options can be found at https://charmhub.io/vault-k8s/configure."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "model" {
+  description = "Reference to a `juju_model`."
+  type        = string
+  default     = ""
+}
+
+variable "revision" {
+  description = "Revision number of the charm"
+  type        = number
+  default     = null
+}
+
+variable "base" {
+  description = "The operating system on which to deploy"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
+variable "units" {
+  description = "Number of units to deploy"
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.units == 1
+    error_message = "Scaling is not supported for this charm."
+  }
+
+}

--- a/k8s/terraform/variables.tf
+++ b/k8s/terraform/variables.tf
@@ -48,9 +48,4 @@ variable "units" {
   type        = number
   default     = 1
 
-  validation {
-    condition     = var.units == 1
-    error_message = "Scaling is not supported for this charm."
-  }
-
 }

--- a/k8s/terraform/variables.tf
+++ b/k8s/terraform/variables.tf
@@ -10,7 +10,7 @@ variable "app_name" {
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "beta"
+  default     = "1.17/stable"
 }
 
 variable "config" {

--- a/k8s/terraform/versions.tf
+++ b/k8s/terraform/versions.tf
@@ -1,0 +1,11 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.18.0"
+    }
+  }
+}

--- a/machine/terraform/README.md
+++ b/machine/terraform/README.md
@@ -1,6 +1,6 @@
-# Vault K8s Terraform module
+# Vault Terraform module
 
-This folder contains a base [Terraform][Terraform] module for the `vault-k8s` charm.
+This folder contains a base [Terraform][Terraform] module for the `vault` charm.
 
 The module uses the [Terraform Juju provider][Terraform Juju provider] to model the charm deployment onto any Kubernetes environment managed by [Juju][Juju].
 
@@ -10,12 +10,12 @@ The base module is not intended to be deployed in separation (it is possible tho
 
 ### Pre-requisites
 
-- A Kubernetes cluster
-- A Juju controller bootstrapped onto the Kubernetes cluster
+- A Machine environment
+- A Juju controller bootstrapped onto the machine environment
 - The Juju client
 - Terraform
 
-### Deploying Vault K8s
+### Deploying Vault
 
 On the host machine create a new directory called terraform:
 
@@ -39,7 +39,7 @@ terraform {
 EOF
 ```
 
-Create a Terraform module containing Vault K8s:
+Create a Terraform module containing Vault:
 
 ```shell
 cat << EOF > main.tf
@@ -47,8 +47,8 @@ resource "juju_model" "demo" {
   name = "demo"
 }
 
-module "vault-k8s" {
-  source = "git::https://github.com/canonical/vault-k8s-operator//k8s/terraform"
+module "vault" {
+  source = "git::https://github.com/canonical/vault-k8s-operator//machine/terraform"
   
   model      = juju_model.demo.name
 }
@@ -71,7 +71,7 @@ terraform apply
 
 ### Create integrations
 
-Add the following content to your module's `main.tf` file to create the integration between the `vault-k8s` charm and other charms.
+Add the following content to your module's `main.tf` file to create the integration between the `vault` charm and other charms.
 
 ```text
 resource "juju_integration" "vault-kv-integration" {
@@ -83,8 +83,8 @@ resource "juju_integration" "vault-kv-integration" {
   }
 
   application {
-    name     = module.vault-k8s.app_name
-    endpoint = module.vault-k8s.provides.vault-kv
+    name     = module.vault.app_name
+    endpoint = module.vault.provides.vault-kv
   }
 }
 ```
@@ -101,5 +101,4 @@ resource "juju_integration" "vault-kv-integration" {
 [Terraform]: https://www.terraform.io/
 [Terraform Juju provider]: https://registry.terraform.io/providers/juju/juju/latest
 [Juju]: https://juju.is
-[vault-k8s-integrations]: https://charmhub.io/vault-k8s/integrations
-[set-up-environment]: [https://discourse.charmhub.io/t/set-up-your-development-environment-with-microk8s-for-juju-terraform-provider/13109#prepare-development-environment-2]
+[vault-integrations]: https://charmhub.io/vault/integrations

--- a/machine/terraform/README.md
+++ b/machine/terraform/README.md
@@ -2,7 +2,7 @@
 
 This folder contains a base [Terraform][Terraform] module for the `vault` charm.
 
-The module uses the [Terraform Juju provider][Terraform Juju provider] to model the charm deployment onto any Kubernetes environment managed by [Juju][Juju].
+The module uses the [Terraform Juju provider][Terraform Juju provider] to model the charm deployment onto any Machine environment managed by [Juju][Juju].
 
 The base module is not intended to be deployed in separation (it is possible though), but should rather serve as a building block for higher level modules.
 

--- a/machine/terraform/README.md
+++ b/machine/terraform/README.md
@@ -32,7 +32,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.12.0"
+      version = "~= 0.18.0"
     }
   }
 }

--- a/machine/terraform/main.tf
+++ b/machine/terraform/main.tf
@@ -1,0 +1,18 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "vault" {
+  name  = var.app_name
+  model = var.model
+
+  charm {
+    name     = "vault"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  units       = var.units
+}

--- a/machine/terraform/outputs.tf
+++ b/machine/terraform/outputs.tf
@@ -1,0 +1,31 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.vault.name
+}
+
+output "requires" {
+  value = {
+    vault-autounseal-requires = "vault-autounseal-requires"
+    ingress                   = "ingress"
+    ingress-per-unit          = "ingress-per-unit"
+    tls-certificates-access   = "tls-certificates-access"
+    tls-certificates-pki      = "tls-certificates-pki"
+    logging                   = "logging"
+    s3-parameters             = "s3-parameters"
+    tracing                   = "tracing"
+  }
+}
+
+output "provides" {
+  value = {
+    vault-autounseal-provides = "vault-autounseal-provides"
+    vault-kv                  = "vault-kv"
+    vault-pki                 = "vault-pki"
+    metrics-endpoint          = "metrics-endpoint"
+    send-ca-cert              = "send-ca-cert"
+    grafana-dashboard         = "grafana-dashboard"
+  }
+}

--- a/machine/terraform/variables.tf
+++ b/machine/terraform/variables.tf
@@ -1,0 +1,56 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "vault-k8s"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying a charm."
+  type        = string
+  default     = "1.17/stable"
+}
+
+variable "config" {
+  description = "Application config. Details about available options can be found at https://charmhub.io/vault-k8s/configure."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "model" {
+  description = "Reference to a `juju_model`."
+  type        = string
+  default     = ""
+}
+
+variable "revision" {
+  description = "Revision number of the charm"
+  type        = number
+  default     = null
+}
+
+variable "base" {
+  description = "The operating system on which to deploy"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
+variable "units" {
+  description = "Number of units to deploy"
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.units == 1
+    error_message = "Scaling is not supported for this charm."
+  }
+
+}

--- a/machine/terraform/variables.tf
+++ b/machine/terraform/variables.tf
@@ -4,7 +4,7 @@
 variable "app_name" {
   description = "Name of the application in the Juju model."
   type        = string
-  default     = "vault-k8s"
+  default     = "vault"
 }
 
 variable "channel" {
@@ -14,7 +14,7 @@ variable "channel" {
 }
 
 variable "config" {
-  description = "Application config. Details about available options can be found at https://charmhub.io/vault-k8s/configure."
+  description = "Application config. Details about available options can be found at https://charmhub.io/vault/configure."
   type        = map(string)
   default     = {}
 }

--- a/machine/terraform/variables.tf
+++ b/machine/terraform/variables.tf
@@ -48,9 +48,4 @@ variable "units" {
   type        = number
   default     = 1
 
-  validation {
-    condition     = var.units == 1
-    error_message = "Scaling is not supported for this charm."
-  }
-
 }

--- a/machine/terraform/versions.tf
+++ b/machine/terraform/versions.tf
@@ -1,0 +1,11 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.18.0"
+    }
+  }
+}


### PR DESCRIPTION
# Description

Add Terraform modules for operating Vault in both Kubernetes and Machine models.

## Usage (K8s)

### Pre-requisites

- A Kubernetes cluster
- A Juju controller bootstrapped onto the Kubernetes cluster
- The Juju client
- Terraform

### Deploying Vault K8s

On the host machine create a new directory called terraform:

```shell
mkdir terraform
```

Inside newly created terraform directory create a versions.tf file:

```shell
cd terraform
cat << EOF > versions.tf
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
      version = ">= 0.12.0"
    }
  }
}
EOF
```

Create a Terraform module containing Vault K8s:

```shell
cat << EOF > main.tf
resource "juju_model" "demo" {
  name = "demo"
}

module "vault-k8s" {
  source = "git::https://github.com/canonical/vault-k8s-operator//k8s/terraform?ref=dev-tf"
  
  model      = juju_model.demo.name
}
EOF
```

Initialize Juju Terraform provider:

```shell
terraform init
```

Deploy the module:

```shell
terraform apply
```

## Reference
- [Terraform](https://www.terraform.io/)
- [Terraform Juju provider](https://registry.terraform.io/providers/juju/juju/latest)
- [Terraform modules organization in the Juju ecosystem](https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit?tab=t.0)

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
