### PR TITLE
feat: Enable ACME in Vault charms

### DIFF
--- a/k8s/charmcraft.yaml
+++ b/k8s/charmcraft.yaml
@@ -113,8 +113,8 @@ requires:
     interface: tls-certificates
     limit: 1
     description: |
-      Interface to be used to provide Vault with its ACME certificate. Vault will
-      use this certificate to sign the certificates it issues on the `vault-acme` interface.
+      Interface to be used to provide Vault with and intermediate CA certificate for the ACME server.
+      Vault will use this certificate to sign the certificates it issues using the ACME protocol.
     optional: true
   logging:
     interface: loki_push_api

--- a/k8s/charmcraft.yaml
+++ b/k8s/charmcraft.yaml
@@ -113,7 +113,7 @@ requires:
     interface: tls-certificates
     limit: 1
     description: |
-      Interface to be used to provide Vault with and intermediate CA certificate for the ACME server.
+      Interface to be used to provide Vault with an intermediate CA certificate for the ACME server.
       Vault will use this certificate to sign the certificates it issues using the ACME protocol.
     optional: true
   logging:

--- a/k8s/charmcraft.yaml
+++ b/k8s/charmcraft.yaml
@@ -109,6 +109,13 @@ requires:
       Interface to be used to provide Vault with its CA certificate. Vault will
       use this certificate to sign the certificates it issues on the `vault-pki` interface.
     optional: true
+  tls-certificates-acme:
+    interface: tls-certificates
+    limit: 1
+    description: |
+      Interface to be used to provide Vault with its ACME certificate. Vault will
+      use this certificate to sign the certificates it issues on the `vault-acme` interface.
+    optional: true
   logging:
     interface: loki_push_api
     optional: true

--- a/k8s/lib/vault/vault_client.py
+++ b/k8s/lib/vault/vault_client.py
@@ -477,6 +477,18 @@ class VaultClient:
             max_ttl,
         )
 
+    def create_or_update_acme_role(self, role: str, mount: str, max_ttl: str) -> None:
+        """Create a role for the ACME backend or update it if it already exists."""
+        self._client.secrets.pki.create_or_update_role(
+            name=role,
+            mount_point=mount,
+            extra_params={
+                "allow_any_name": True,
+                "allow_subdomains": True,
+                "max_ttl": max_ttl,
+            },
+        )
+
     def is_pki_role_created(self, role: str, mount: str) -> bool:
         """Check if the role is created for the PKI backend."""
         try:
@@ -588,6 +600,16 @@ class VaultClient:
     def delete_policy(self, name: str) -> None:
         """Delete the policy with the given name."""
         return self._client.sys.delete_policy(name)
+
+    def set_urls(
+        self, mount: str, issuing_certificates: List[str], crl_distribution_points: List[str]
+    ) -> None:
+        """Set the URLs for the ACME backend."""
+        self._client.secrets.pki.set_urls(
+            mount_point=mount,
+            issuing_certificates=issuing_certificates,
+            crl_distribution_points=crl_distribution_points,
+        )
 
 
 def generate_pem_bundle(certificate: str, private_key: str) -> str:

--- a/k8s/lib/vault/vault_client.py
+++ b/k8s/lib/vault/vault_client.py
@@ -616,11 +616,9 @@ class VaultClient:
     def tune_pki_backend(self, mount: str) -> None:
         """Tune the PKI backend."""
         self._client.sys.tune_mount_configuration(
-            path=mount,
-            **{
-                'allowed_response_headers': ['Location', 'Replay-Nonce', 'Link']
-            }
+            path=mount, **{"allowed_response_headers": ["Location", "Replay-Nonce", "Link"]}
         )
+
 
 def generate_pem_bundle(certificate: str, private_key: str) -> str:
     """Generate a PEM bundle from a certificate and private key."""

--- a/k8s/lib/vault/vault_client.py
+++ b/k8s/lib/vault/vault_client.py
@@ -607,10 +607,20 @@ class VaultClient:
         """Set the URLs for the ACME backend."""
         self._client.secrets.pki.set_urls(
             mount_point=mount,
-            issuing_certificates=issuing_certificates,
-            crl_distribution_points=crl_distribution_points,
+            params={
+                "issuing_certificates": issuing_certificates,
+                "crl_distribution_points": crl_distribution_points,
+            },
         )
 
+    def tune_pki_backend(self, mount: str) -> None:
+        """Tune the PKI backend."""
+        self._client.sys.tune_mount_configuration(
+            path=mount,
+            **{
+                'allowed_response_headers': ['Location', 'Replay-Nonce', 'Link']
+            }
+        )
 
 def generate_pem_bundle(certificate: str, private_key: str) -> str:
     """Generate a PEM bundle from a certificate and private key."""

--- a/k8s/lib/vault/vault_client.py
+++ b/k8s/lib/vault/vault_client.py
@@ -613,8 +613,8 @@ class VaultClient:
             },
         )
 
-    def tune_pki_backend(self, mount: str) -> None:
-        """Tune the PKI backend."""
+    def allow_acme_headers(self, mount: str) -> None:
+        """Allow the ACME headers to be returned by the Vault server."""
         self._client.sys.tune_mount_configuration(
             path=mount, **{"allowed_response_headers": ["Location", "Replay-Nonce", "Link"]}
         )

--- a/k8s/lib/vault/vault_managers.py
+++ b/k8s/lib/vault/vault_managers.py
@@ -1531,6 +1531,9 @@ class AcmeManager:
             private_key=str(private_key),
             mount=self._mount_point,
         )
+        self._vault_client.tune_pki_backend(
+            mount=self._mount_point,
+        )
         self._vault_client.set_urls(
             issuing_certificates=[f"{self._vault_address}/v1/pki/ca"],
             crl_distribution_points=[f"{self._vault_address}/v1/pki/crl"],

--- a/k8s/lib/vault/vault_managers.py
+++ b/k8s/lib/vault/vault_managers.py
@@ -105,18 +105,6 @@ path "sys/internal/ui/mounts/{mount}" {{
 """
 
 
-def get_vault_service_ca_certificate(client: VaultClient, mount: str) -> Certificate | None:
-    """Get the current CA certificate from the Vault service."""
-    try:
-        intermediate_ca_cert = client.get_intermediate_ca(mount=mount)
-        if not intermediate_ca_cert:
-            return None
-        return Certificate.from_string(intermediate_ca_cert)
-    except (VaultClientError, TLSCertificatesError) as e:
-        logger.error("Failed to get current CA certificate: %s", e)
-        return None
-
-
 class LogAdapter(logging.LoggerAdapter):
     """Adapter for the logger to prepend a prefix to all log lines."""
 
@@ -660,6 +648,17 @@ class _PKIUtils:
         self._vault_client = vault_client
         self._mount_point = mount_point
 
+    def get_vault_service_ca_certificate(self) -> Certificate | None:
+        """Get the current intermediate CA certificate from the Vault service."""
+        try:
+            intermediate_ca_cert = self._vault_client.get_intermediate_ca(mount=self._mount_point)
+            if not intermediate_ca_cert:
+                return None
+            return Certificate.from_string(intermediate_ca_cert)
+        except (VaultClientError, TLSCertificatesError) as e:
+            logger.error("Failed to get current CA certificate: %s", e)
+            return None
+
     def make_latest_issuer_default(self):
         """Make the latest PKI issuer the default issuer.
 
@@ -1008,9 +1007,7 @@ class PKIManager:
         certificate_from_provider, private_key = self._get_pki_intermediate_ca_from_relation()
         if not certificate_from_provider or not private_key:
             return
-        vault_service_ca_certificate = get_vault_service_ca_certificate(
-            self._vault_client, self._mount_point
-        )
+        vault_service_ca_certificate = self._pki_utils.get_vault_service_ca_certificate()
         if (
             vault_service_ca_certificate
             and vault_service_ca_certificate == certificate_from_provider.certificate
@@ -1542,13 +1539,12 @@ class ACMEManager:
         return provider_certificate, private_key
 
     def _configure_intermediate_ca_certificate(self) -> None:
+        """Configure the intermediate CA certificate for the ACME server in Vault."""
         certificate_from_provider, private_key = self._get_acme_intermediate_ca_from_relation()
         if not certificate_from_provider or not private_key:
             raise ManagerError("No intermediate CA certificate available for Vault ACME")
 
-        vault_service_ca_certificate = get_vault_service_ca_certificate(
-            self._vault_client, self._mount_point
-        )
+        vault_service_ca_certificate = self._pki_utils.get_vault_service_ca_certificate()
         if (
             vault_service_ca_certificate
             and vault_service_ca_certificate == certificate_from_provider.certificate
@@ -1573,6 +1569,7 @@ class ACMEManager:
         )
 
     def _configure_acme_role(self) -> None:
+        """Configure the ACME role in Vault."""
         certificate_from_provider, _ = self._get_acme_intermediate_ca_from_relation()
         if not certificate_from_provider:
             logger.debug("No intermediate CA certificate available for Vault ACME")
@@ -1588,6 +1585,7 @@ class ACMEManager:
             )
 
     def _enable_acme(self) -> None:
+        """Configure ACME to be enabled in Vault."""
         self._vault_client.write(path=f"{self._mount_point}/config/acme", data={"enabled": True})
 
     def make_latest_acme_issuer_default(self):
@@ -1595,7 +1593,7 @@ class ACMEManager:
         self._pki_utils.make_latest_issuer_default()
 
     def configure(self) -> None:
-        """Configure the ACME engine in Vault."""
+        """Configure the ACME server in Vault."""
         if not self._juju_facade.is_leader:
             logger.debug("Only leader unit can configure ACME")
             return
@@ -1614,7 +1612,7 @@ class ACMEManager:
 
         self._configure_acme_role()
 
-        self._vault_client.tune_pki_backend(
+        self._vault_client.allow_acme_headers(
             mount=self._mount_point,
         )
         self._vault_client.set_urls(

--- a/k8s/tests/unit/fixtures.py
+++ b/k8s/tests/unit/fixtures.py
@@ -10,6 +10,7 @@ from vault.vault_client import (
     VaultClient,
 )
 from vault.vault_managers import (
+    ACMEManager,
     AutounsealProviderManager,
     AutounsealRequirerManager,
     BackupManager,
@@ -35,12 +36,13 @@ class VaultCharmFixtures:
             ) as mock_autounseal_requirer_manager,
             patch("charm.KVManager", autospec=KVManager) as mock_kv_manager,
             patch("charm.PKIManager", autospec=PKIManager) as mock_pki_manager,
+            patch("charm.ACMEManager", autospec=ACMEManager) as mock_acme_manager,
             patch("charm.S3Requirer", autospec=S3Requirer) as mock_s3_requirer,
             patch("charm.BackupManager", autospec=BackupManager) as mock_backup_manager,
             patch("socket.getfqdn") as mock_socket_fqdn,
             patch(
                 "charm.TLSCertificatesRequiresV4.get_assigned_certificate"
-            ) as mock_pki_requirer_get_assigned_certificate,
+            ) as mock_get_requirer_assigned_certificate,
             patch(
                 "charm.TLSCertificatesRequiresV4.renew_certificate"
             ) as mock_pki_requirer_renew_certificate,
@@ -75,14 +77,13 @@ class VaultCharmFixtures:
             )
             self.mock_kv_manager = mock_kv_manager.return_value
             self.mock_pki_manager = mock_pki_manager.return_value
+            self.mock_acme_manager = mock_acme_manager.return_value
             self.mock_s3_requirer = mock_s3_requirer.return_value
             self.mock_backup_manager = mock_backup_manager.return_value
 
             # When we want to mock the callable, we use the mock directly
             self.mock_socket_fqdn = mock_socket_fqdn
-            self.mock_pki_requirer_get_assigned_certificate = (
-                mock_pki_requirer_get_assigned_certificate
-            )
+            self.mock_get_requirer_assigned_certificate = mock_get_requirer_assigned_certificate
             self.mock_pki_requirer_renew_certificate = mock_pki_requirer_renew_certificate
             self.mock_pki_provider_get_outstanding_certificate_requests = (
                 mock_pki_provider_get_outstanding_certificate_requests

--- a/k8s/tests/unit/lib/test_vault_managers.py
+++ b/k8s/tests/unit/lib/test_vault_managers.py
@@ -649,7 +649,6 @@ class TestACMEManager:
     def test_given_intermediate_certificate_when_configure_then_role_created(
         self, assigned_certificate_and_key: tuple[ProviderCertificate, PrivateKey]
     ):
-        # TODO, change this mock
         vault_certificate, _ = generate_example_provider_certificate(
             self.certificate_request_attributes.common_name, 1, validity=timedelta(hours=24)
         )
@@ -677,7 +676,6 @@ class TestACMEManager:
     def test_given_intermediate_certificate_when_configure_then_backend_configured(
         self, assigned_certificate_and_key: tuple[ProviderCertificate, PrivateKey]
     ):
-        # TODO, change this mock
         vault_certificate, _ = generate_example_provider_certificate(
             self.certificate_request_attributes.common_name, 1, validity=timedelta(hours=24)
         )
@@ -694,7 +692,7 @@ class TestACMEManager:
         ]
         self.vault.write.assert_has_calls(expected_write_calls, any_order=True)
 
-        self.vault.tune_pki_backend.assert_called_once_with(mount=self.mount_point)
+        self.vault.allow_acme_headers.assert_called_once_with(mount=self.mount_point)
 
         self.vault.set_urls.assert_called_once_with(
             mount=self.mount_point,

--- a/k8s/tests/unit/lib/test_vault_managers.py
+++ b/k8s/tests/unit/lib/test_vault_managers.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from charms.data_platform_libs.v0.s3 import S3Requirer
@@ -14,6 +14,7 @@ from vault.vault_client import (
 from vault.vault_client import Certificate as VaultClientCertificate
 from vault.vault_managers import (
     AUTOUNSEAL_POLICY,
+    ACMEManager,
     AutounsealProviderManager,
     AutounsealRequirerManager,
     BackupManager,
@@ -519,6 +520,186 @@ class TestPKIManager:
                 ca=provider_certificate.certificate,
                 chain=provider_certificate.chain,
             )
+        )
+
+
+class TestACMEManager:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.charm = MagicMock(spec=VaultCharm)
+        self.vault = MagicMock(spec=VaultClient)
+        self.mount_point = "acme-charm"
+        self.tls_certificates_acme = MagicMock(spec=TLSCertificatesRequiresV4)
+        self.certificate_request_attributes = CertificateRequestAttributes(
+            common_name="common_name",
+            is_ca=True,
+        )
+        self.role_name = "acme-charm-role"
+        self.vault_address = "https://vault:8200"
+        self.acme_manager = ACMEManager(
+            self.charm,
+            self.vault,
+            self.mount_point,
+            self.tls_certificates_acme,
+            self.certificate_request_attributes,
+            self.role_name,
+            self.vault_address,
+        )
+
+    @pytest.fixture
+    def one_issuer(self) -> str:
+        self.vault.list_pki_issuers.return_value = ["issuer"]
+        return "issuer"
+
+    @pytest.fixture
+    def no_issuer(self):
+        self.vault.list_pki_issuers.return_value = []
+
+    @pytest.fixture
+    def issuer_is_default(self, one_issuer: str):
+        self.vault.read.return_value = {
+            "data": {"default_follows_latest_issuer": True, "default": one_issuer}
+        }
+
+    @pytest.fixture
+    def issuer_is_not_default(self, one_issuer: str):
+        self.vault.read.return_value = {
+            "default_follows_latest_issuer": False,
+            "default": one_issuer,
+        }
+
+    @pytest.fixture
+    def assigned_certificate_and_key(self) -> tuple[ProviderCertificate, PrivateKey]:
+        provider_certificate, private_key = generate_example_provider_certificate(
+            self.certificate_request_attributes.common_name, 1, validity=timedelta(hours=24)
+        )
+        self.tls_certificates_acme.get_assigned_certificate.return_value = (
+            provider_certificate,
+            private_key,
+        )
+        return (provider_certificate, private_key)
+
+    def test_given_no_acme_issuers_when_make_latest_acme_issuer_default_then_no_vault_error_is_raised_but_error_is_logged(
+        self, caplog: pytest.LogCaptureFixture, no_issuer: None
+    ):
+        # Ensure no error is raised
+        self.acme_manager.make_latest_acme_issuer_default()
+
+        assert is_error_logged(caplog, "Failed to get the first issuer")
+
+    def test_given_existing_acme_issuers_when_make_latest_acme_issuer_default_then_config_written_to_path(
+        self, issuer_is_not_default: None
+    ):
+        self.acme_manager.make_latest_acme_issuer_default()
+
+        self.vault.write.assert_called_with(
+            path=f"{self.mount_point}/config/issuers",
+            data={
+                "default_follows_latest_issuer": True,
+                "default": "issuer",
+            },
+        )
+
+    def test_given_issuers_config_already_updated_when_make_latest_acme_issuer_default_then_config_not_written(
+        self, issuer_is_default: None
+    ):
+        self.acme_manager.make_latest_acme_issuer_default()
+        self.vault.write.assert_not_called()
+
+    def test_given_intermediate_certificate_expires_before_issued_certificates_when_configure_then_certificate_is_renewed(
+        self, assigned_certificate_and_key: tuple[ProviderCertificate, PrivateKey]
+    ):
+        provider_certificate, _ = assigned_certificate_and_key
+
+        self.vault.get_intermediate_ca.return_value = str(provider_certificate.certificate)
+
+        # This is how long certificates issued by ACME will be valid for. We
+        # make it 25 hours, because the intermediate (provider) certificate is valid for 24.
+        self.vault.get_role_max_ttl.return_value = 25 * SECONDS_IN_HOUR
+
+        self.acme_manager.configure()
+
+        self.vault.enable_secrets_engine.assert_called_once_with(
+            SecretsBackend.PKI, self.mount_point
+        )
+        self.tls_certificates_acme.renew_certificate.assert_called_once_with(provider_certificate)
+
+    def test_given_new_certificate_issued_when_configure_then_certificates_replaced(
+        self, assigned_certificate_and_key: tuple[ProviderCertificate, PrivateKey]
+    ):
+        # Return a different certificate from Vault, to emulate the situation
+        # where a new certificate has been issued.
+        vault_certificate, private_key = generate_example_provider_certificate(
+            self.certificate_request_attributes.common_name, 1, validity=timedelta(hours=24)
+        )
+        self.vault.get_intermediate_ca.return_value = str(vault_certificate.certificate)
+
+        self.acme_manager.configure()
+
+        self.vault.enable_secrets_engine.assert_called_once_with(
+            SecretsBackend.PKI, self.mount_point
+        )
+
+        self.vault.import_ca_certificate_and_key.assert_called_once_with(
+            certificate=str(assigned_certificate_and_key[0].certificate),
+            private_key=str(assigned_certificate_and_key[1]),
+            mount=self.mount_point,
+        )
+
+    def test_given_intermediate_certificate_when_configure_then_role_created(
+        self, assigned_certificate_and_key: tuple[ProviderCertificate, PrivateKey]
+    ):
+        # TODO, change this mock
+        vault_certificate, _ = generate_example_provider_certificate(
+            self.certificate_request_attributes.common_name, 1, validity=timedelta(hours=24)
+        )
+        self.vault.get_intermediate_ca.return_value = str(vault_certificate.certificate)
+
+        self.acme_manager.configure()
+
+        self.vault.enable_secrets_engine.assert_called_once_with(
+            SecretsBackend.PKI, self.mount_point
+        )
+
+        validity = (
+            assigned_certificate_and_key[0].certificate.expiry_time
+            - assigned_certificate_and_key[0].certificate.validity_start_time
+        )
+        validity_in_seconds = validity.total_seconds()
+        # This is how the manager currently calculates the max_ttl.
+        max_ttl = int(validity_in_seconds / 2)
+        self.vault.create_or_update_acme_role.assert_called_once_with(
+            mount=self.mount_point,
+            role=self.role_name,
+            max_ttl=f"{max_ttl}s",
+        )
+
+    def test_given_intermediate_certificate_when_configure_then_backend_configured(
+        self, assigned_certificate_and_key: tuple[ProviderCertificate, PrivateKey]
+    ):
+        # TODO, change this mock
+        vault_certificate, _ = generate_example_provider_certificate(
+            self.certificate_request_attributes.common_name, 1, validity=timedelta(hours=24)
+        )
+        self.vault.get_intermediate_ca.return_value = str(vault_certificate.certificate)
+
+        self.acme_manager.configure()
+
+        expected_write_calls = [
+            call.write(
+                path=f"{self.mount_point}/config/cluster",
+                data={"path": f"{self.vault_address}/v1/{self.mount_point}"},
+            ),
+            call.write(path=f"{self.mount_point}/config/acme", data={"enabled": True}),
+        ]
+        self.vault.write.assert_has_calls(expected_write_calls, any_order=True)
+
+        self.vault.tune_pki_backend.assert_called_once_with(mount=self.mount_point)
+
+        self.vault.set_urls.assert_called_once_with(
+            mount=self.mount_point,
+            issuing_certificates=[f"{self.vault_address}/v1/pki/ca"],
+            crl_distribution_points=[f"{self.vault_address}/v1/pki/crl"],
         )
 
 

--- a/k8s/tests/unit/test_charm_collect_status.py
+++ b/k8s/tests/unit/test_charm_collect_status.py
@@ -183,6 +183,42 @@ class TestCharmCollectUnitStatus(VaultCharmFixtures):
             "Common name is not set in the charm config, cannot configure PKI secrets engine"
         )
 
+    def test_given_tls_certificates_acme_relation_and_common_name_not_set_when_collect_unit_status_then_status_is_blocked(  # noqa: E501
+        self,
+    ):
+        self.mock_tls.configure_mock(
+            **{
+                "tls_file_available_in_charm.return_value": True,
+                "ca_certificate_secret_exists.return_value": True,
+                "tls_file_pushed_to_workload.return_value": True,
+            },
+        )
+        self.mock_vault.configure_mock(
+            **{
+                "is_api_available.return_value": True,
+            },
+        )
+        container = testing.Container(
+            name="vault",
+            can_connect=True,
+        )
+        peer_relation = testing.PeerRelation(
+            endpoint="vault-peers",
+        )
+        acme_relation = testing.Relation(
+            endpoint="tls-certificates-acme",
+        )
+        state_in = testing.State(
+            containers=[container],
+            relations=[peer_relation, acme_relation],
+        )
+
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
+
+        assert state_out.unit_status == BlockedStatus(
+            "Common name is not set in the charm config, cannot configure ACME server"
+        )
+
     def test_given_vault_uninitialized_when_collect_unit_status_then_status_is_blocked(self):
         self.mock_tls.configure_mock(
             **{

--- a/k8s/tests/unit/test_charm_configure.py
+++ b/k8s/tests/unit/test_charm_configure.py
@@ -164,7 +164,7 @@ class TestCharmConfigure(VaultCharmFixtures):
                 relation_id=pki_relation.id,
                 validity=timedelta(hours=24),
             )
-            self.mock_pki_requirer_get_assigned_certificate.return_value = (
+            self.mock_get_requirer_assigned_certificate.return_value = (
                 provider_certificate,
                 private_key,
             )
@@ -172,6 +172,68 @@ class TestCharmConfigure(VaultCharmFixtures):
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
 
             self.mock_pki_manager.configure.assert_called_once()
+
+    # Test ACME
+
+    def test_given_certificate_available_when_configure_then_acme_server_is_configured(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.mock_vault.configure_mock(
+                **{
+                    "is_api_available.return_value": True,
+                    "authenticate.return_value": True,
+                    "is_initialized.return_value": True,
+                    "is_sealed.return_value": False,
+                    "is_active_or_standby.return_value": True,
+                    "get_intermediate_ca.return_value": "",
+                },
+            )
+            self.mock_autounseal_requires_get_details.return_value = None
+            vault_config_mount = testing.Mount(
+                location="/vault/config",
+                source=temp_dir,
+            )
+            container = testing.Container(
+                name="vault",
+                can_connect=True,
+                mounts={
+                    "vault-config": vault_config_mount,
+                },
+            )
+            peer_relation = testing.PeerRelation(
+                endpoint="vault-peers",
+            )
+            acme_relation = testing.Relation(
+                endpoint="tls-certificates-acme",
+                interface="tls-certificates",
+            )
+            approle_secret = testing.Secret(
+                label="vault-approle-auth-details",
+                tracked_content={"role-id": "role id", "secret-id": "secret id"},
+            )
+            state_in = testing.State(
+                containers=[container],
+                leader=True,
+                secrets=[approle_secret],
+                relations=[peer_relation, acme_relation],
+                config={
+                    "common_name": "myhostname.com",
+                },
+            )
+            provider_certificate, private_key = generate_example_provider_certificate(
+                common_name="myhostname.com",
+                relation_id=acme_relation.id,
+                validity=timedelta(hours=24),
+            )
+            self.mock_get_requirer_assigned_certificate.return_value = (
+                provider_certificate,
+                private_key,
+            )
+
+            self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
+
+            self.mock_acme_manager.configure.assert_called_once()
 
     # Test Auto unseal
 

--- a/machine/charmcraft.yaml
+++ b/machine/charmcraft.yaml
@@ -74,6 +74,13 @@ requires:
       Interface to be used to provide Vault with its CA certificate. Vault will
       use this certificate to sign the certificates it issues on the `vault-pki` interface.
     optional: true
+  tls-certificates-acme:
+    interface: tls-certificates
+    limit: 1
+    description: |
+      Interface to be used to provide Vault with and intermediate CA certificate for the ACME server.
+      Vault will use this certificate to sign the certificates it issues using the ACME protocol.
+    optional: true
   s3-parameters:
     interface: s3
     optional: true

--- a/machine/charmcraft.yaml
+++ b/machine/charmcraft.yaml
@@ -78,7 +78,7 @@ requires:
     interface: tls-certificates
     limit: 1
     description: |
-      Interface to be used to provide Vault with and intermediate CA certificate for the ACME server.
+      Interface to be used to provide Vault with an intermediate CA certificate for the ACME server.
       Vault will use this certificate to sign the certificates it issues using the ACME protocol.
     optional: true
   s3-parameters:

--- a/machine/lib/vault/vault_client.py
+++ b/machine/lib/vault/vault_client.py
@@ -477,6 +477,18 @@ class VaultClient:
             max_ttl,
         )
 
+    def create_or_update_acme_role(self, role: str, mount: str, max_ttl: str) -> None:
+        """Create a role for the ACME backend or update it if it already exists."""
+        self._client.secrets.pki.create_or_update_role(
+            name=role,
+            mount_point=mount,
+            extra_params={
+                "allow_any_name": True,
+                "allow_subdomains": True,
+                "max_ttl": max_ttl,
+            },
+        )
+
     def is_pki_role_created(self, role: str, mount: str) -> bool:
         """Check if the role is created for the PKI backend."""
         try:
@@ -588,6 +600,24 @@ class VaultClient:
     def delete_policy(self, name: str) -> None:
         """Delete the policy with the given name."""
         return self._client.sys.delete_policy(name)
+
+    def set_urls(
+        self, mount: str, issuing_certificates: List[str], crl_distribution_points: List[str]
+    ) -> None:
+        """Set the URLs for the ACME backend."""
+        self._client.secrets.pki.set_urls(
+            mount_point=mount,
+            params={
+                "issuing_certificates": issuing_certificates,
+                "crl_distribution_points": crl_distribution_points,
+            },
+        )
+
+    def allow_acme_headers(self, mount: str) -> None:
+        """Allow the ACME headers to be returned by the Vault server."""
+        self._client.sys.tune_mount_configuration(
+            path=mount, **{"allowed_response_headers": ["Location", "Replay-Nonce", "Link"]}
+        )
 
 
 def generate_pem_bundle(certificate: str, private_key: str) -> str:

--- a/machine/lib/vault/vault_managers.py
+++ b/machine/lib/vault/vault_managers.py
@@ -28,11 +28,11 @@ Feature managers should not:
 - Depend on each other unless the features explicitly require the dependency.
 """
 
+from dataclasses import dataclass
 import json
 import logging
 import os
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum, auto
 from typing import FrozenSet, MutableMapping, TextIO
@@ -83,6 +83,7 @@ from vault.vault_s3 import S3, S3Error
 SEND_CA_CERT_RELATION_NAME = "send-ca-cert"
 TLS_CERTIFICATE_ACCESS_RELATION_NAME = "tls-certificates-access"
 TLS_CERTIFICATES_PKI_RELATION_NAME = "tls-certificates-pki"
+TLS_CERTIFICATES_ACME_RELATION_NAME = "tls-certificates-acme"
 CA_CERTIFICATE_JUJU_SECRET_LABEL = "self-signed-vault-ca-certificate"
 
 VAULT_CA_SUBJECT = "Vault self signed CA"
@@ -103,6 +104,18 @@ path "sys/internal/ui/mounts/{mount}" {{
   capabilities = ["read"]
 }}
 """
+
+
+def get_vault_service_ca_certificate(client: VaultClient, mount: str) -> Certificate | None:
+    """Get the current CA certificate from the Vault service."""
+    try:
+        intermediate_ca_cert = client.get_intermediate_ca(mount=mount)
+        if not intermediate_ca_cert:
+            return None
+        return Certificate.from_string(intermediate_ca_cert)
+    except (VaultClientError, TLSCertificatesError) as e:
+        logger.error("Failed to get current CA certificate: %s", e)
+        return None
 
 
 class LogAdapter(logging.LoggerAdapter):
@@ -641,6 +654,83 @@ class Naming:
         return f"{mount_path}-{unit_name_dash}"
 
 
+class _PKIUtils:
+    """Encapsulates some common util functions among PKIManager and ACMEManager."""
+
+    def __init__(self, vault_client: VaultClient, mount_point: str):
+        self._vault_client = vault_client
+        self._mount_point = mount_point
+
+    def make_latest_issuer_default(self):
+        """Make the latest PKI issuer the default issuer.
+
+        This ensures that the latest issuer we have created is used for signing
+        certificates.
+        """
+        try:
+            first_issuer = self._vault_client.list_pki_issuers(mount=self._mount_point)[0]
+        except (VaultClientError, IndexError) as e:
+            logger.error("Failed to get the first issuer: %s", e)
+            return
+        try:
+            issuers_config = self._vault_client.read(path=f"{self._mount_point}/config/issuers")
+            if issuers_config and not issuers_config["default_follows_latest_issuer"]:
+                logger.debug("Updating issuers config")
+                self._vault_client.write(
+                    path=f"{self._mount_point}/config/issuers",
+                    data={
+                        "default_follows_latest_issuer": True,
+                        "default": first_issuer,
+                    },
+                )
+        except (TypeError, KeyError):
+            logger.error("Issuers config is not yet created")
+
+    def calculate_certificates_ttl(self, certificate: Certificate) -> int:
+        """Calculate the maximum allowed validity of certificates issued by Vault.
+
+        The current implementation returns half the validity of the CA certificate.
+        """
+        if not certificate.expiry_time or not certificate.validity_start_time:
+            raise ValueError("Invalid CA certificate with no expiry time or validity start time")
+        ca_validity_time = certificate.expiry_time - certificate.validity_start_time
+        ca_validity_seconds = ca_validity_time.total_seconds()
+        return int(ca_validity_seconds / 2)
+
+    def intermediate_ca_exceeds_role_ttl(
+        self, intermediate_ca_certificate: Certificate, current_ttl: int
+    ) -> bool:
+        """Check if the intermediate CA's remaining validity exceeds the role's max TTL.
+
+        Vault PKI enforces that issued certificates cannot outlast their signing CA.
+        This method ensures that the intermediate CA's remaining validity period
+        is longer than the maximum TTL allowed for certificates issued by this role.
+        """
+        if (
+            not current_ttl
+            or not intermediate_ca_certificate.expiry_time
+            or not intermediate_ca_certificate.validity_start_time
+        ):
+            return False
+        certificate_validity = (
+            intermediate_ca_certificate.expiry_time
+            - intermediate_ca_certificate.validity_start_time
+        )
+        certificate_validity_seconds = certificate_validity.total_seconds()
+        return certificate_validity_seconds > current_ttl
+
+
+@dataclass
+class AutounsealConfigurationDetails:
+    """Credentials required for configuring auto-unseal on Vault."""
+
+    address: str
+    mount_path: str
+    key_name: str
+    token: str
+    ca_cert_path: str
+
+
 class AutounsealProviderManager:
     """Encapsulates the auto-unseal functionality.
 
@@ -796,16 +886,6 @@ class AutounsealProviderManager:
         output = self._client.list("sys/policy")
         return [policy for policy in output if policy.startswith(Naming.autounseal_policy_prefix)]
 
-@dataclass
-class AutounsealConfigurationDetails:
-    """Credentials required for configuring auto-unseal on Vault."""
-
-    address: str
-    mount_path: str
-    key_name: str
-    token: str
-    ca_cert_path: str
-
 
 class AutounsealRequirerManager:
     """Encapsulates the auto-unseal functionality from the Requirer Perspective.
@@ -898,6 +978,7 @@ class PKIManager:
         self._vault_pki = vault_pki
         self._tls_certificates_pki = tls_certificates_pki
         self._certificate_request_attributes = certificate_request_attributes
+        self._pki_utils = _PKIUtils(vault_client, mount_point)
 
     def _get_pki_intermediate_ca_from_relation(
         self,
@@ -910,44 +991,10 @@ class PKIManager:
             certificate_request=self._certificate_request_attributes
         )
         if not provider_certificate:
-            logger.debug("No intermediate CA certificate available")
+            logger.debug("No intermediate CA certificate available for Vault PKI")
         if not private_key:
-            logger.debug("No private key available")
+            logger.debug("No private key available for Vault PKI")
         return provider_certificate, private_key
-
-    def _get_vault_service_ca_certificate(self) -> Certificate | None:
-        """Get the current CA certificate from the Vault service."""
-        try:
-            intermediate_ca_cert = self._vault_client.get_intermediate_ca(mount=self._mount_point)
-            if not intermediate_ca_cert:
-                return None
-            return Certificate.from_string(intermediate_ca_cert)
-        except (VaultClientError, TLSCertificatesError) as e:
-            logger.error("Failed to get current CA certificate: %s", e)
-            return None
-
-    def _intermediate_ca_exceeds_role_ttl(self, intermediate_ca_certificate: Certificate) -> bool:
-        """Check if the intermediate CA's remaining validity exceeds the role's max TTL.
-
-        Vault PKI enforces that issued certificates cannot outlast their signing CA.
-        This method ensures that the intermediate CA's remaining validity period
-        is longer than the maximum TTL allowed for certificates issued by this role.
-        """
-        current_ttl = self._vault_client.get_role_max_ttl(
-            role=self._role_name, mount=self._mount_point
-        )
-        if (
-            not current_ttl
-            or not intermediate_ca_certificate.expiry_time
-            or not intermediate_ca_certificate.validity_start_time
-        ):
-            return False
-        certificate_validity = (
-            intermediate_ca_certificate.expiry_time
-            - intermediate_ca_certificate.validity_start_time
-        )
-        certificate_validity_seconds = certificate_validity.total_seconds()
-        return certificate_validity_seconds > current_ttl
 
     def configure(self):
         """Enable the PKI backend and update the PKI role in Vault.
@@ -973,12 +1020,19 @@ class PKIManager:
         certificate_from_provider, private_key = self._get_pki_intermediate_ca_from_relation()
         if not certificate_from_provider or not private_key:
             return
-        vault_service_ca_certificate = self._get_vault_service_ca_certificate()
+        vault_service_ca_certificate = get_vault_service_ca_certificate(
+            self._vault_client, self._mount_point
+        )
         if (
             vault_service_ca_certificate
             and vault_service_ca_certificate == certificate_from_provider.certificate
         ):
-            if not self._intermediate_ca_exceeds_role_ttl(vault_service_ca_certificate):
+            current_ttl = self._vault_client.get_role_max_ttl(
+                role=self._role_name, mount=self._mount_point
+            )
+            if current_ttl and not self._pki_utils.intermediate_ca_exceeds_role_ttl(
+                vault_service_ca_certificate, current_ttl
+            ):
                 self._tls_certificates_pki.renew_certificate(
                     certificate_from_provider,
                 )
@@ -992,7 +1046,7 @@ class PKIManager:
             private_key=str(private_key),
             mount=self._mount_point,
         )
-        issued_certificates_validity = PKIManager.calculate_pki_certificates_ttl(
+        issued_certificates_validity = self._pki_utils.calculate_certificates_ttl(
             certificate_from_provider.certificate
         )
         if not self._vault_client.is_common_name_allowed_in_pki_role(
@@ -1011,29 +1065,8 @@ class PKIManager:
         self.make_latest_pki_issuer_default()
 
     def make_latest_pki_issuer_default(self):
-        """Make the latest PKI issuer the default issuer.
-
-        This ensures that the latest issuer we have created is used for signing
-        certificates.
-        """
-        try:
-            first_issuer = self._vault_client.list_pki_issuers(mount=self._mount_point)[0]
-        except (VaultClientError, IndexError) as e:
-            logger.error("Failed to get the first issuer: %s", e)
-            return
-        try:
-            issuers_config = self._vault_client.read(path=f"{self._mount_point}/config/issuers")
-            if issuers_config and not issuers_config["default_follows_latest_issuer"]:
-                logger.debug("Updating issuers config")
-                self._vault_client.write(
-                    path=f"{self._mount_point}/config/issuers",
-                    data={
-                        "default_follows_latest_issuer": True,
-                        "default": first_issuer,
-                    },
-                )
-        except (TypeError, KeyError):
-            logger.error("Issuers config is not yet created")
+        """Make the latest issuer the default issuer."""
+        self._pki_utils.make_latest_issuer_default()
 
     def sync(self):
         """Sync the state of the PKI backend with the TLS certificates relations.
@@ -1061,7 +1094,7 @@ class PKIManager:
         provider_certificate, _ = self._get_pki_intermediate_ca_from_relation()
         if not provider_certificate:
             return
-        allowed_cert_validity = PKIManager.calculate_pki_certificates_ttl(
+        allowed_cert_validity = self._pki_utils.calculate_certificates_ttl(
             provider_certificate.certificate
         )
         certificate = self._vault_client.sign_pki_certificate_signing_request(
@@ -1084,18 +1117,6 @@ class PKIManager:
         self._vault_pki.set_relation_certificate(
             provider_certificate=provider_certificate,
         )
-
-    @staticmethod
-    def calculate_pki_certificates_ttl(certificate: Certificate) -> int:
-        """Calculate the maximum allowed validity of certificates issued by PKI.
-
-        The current implementation returns half the validity of the CA certificate.
-        """
-        if not certificate.expiry_time or not certificate.validity_start_time:
-            raise ValueError("Invalid CA certificate with no expiry time or validity start time")
-        ca_validity_time = certificate.expiry_time - certificate.validity_start_time
-        ca_validity_seconds = ca_validity_time.total_seconds()
-        return int(ca_validity_seconds / 2)
 
 
 class KVManager:
@@ -1491,3 +1512,131 @@ class RaftManager:
         ``node_id`` and ``address`` provided.
         """
         return json.dumps([{"id": node_id, "address": address}])
+
+
+class ACMEManager:
+    """Encapsulates the business logic for managing the ACME engine in Vault."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        vault_client: VaultClient,
+        mount_point: str,
+        tls_certificates_acme: TLSCertificatesRequiresV4,
+        certificate_request_attributes: CertificateRequestAttributes,
+        role_name: str,
+        vault_address: str,
+    ):
+        self._charm = charm
+        self._juju_facade = JujuFacade(charm)
+        self._vault_client = vault_client
+        self._mount_point = mount_point
+        self._tls_certificates_acme = tls_certificates_acme
+        self._certificate_request_attributes = certificate_request_attributes
+        self._role_name = role_name
+        self._vault_address = vault_address
+        self._pki_utils = _PKIUtils(vault_client, mount_point)
+
+    def _get_acme_intermediate_ca_from_relation(
+        self,
+    ) -> tuple[ProviderCertificate | None, PrivateKey | None]:
+        """Get the intermediate CA certificate and private key from the relation data.
+
+        This is the CA certificate that the provider charm has issued to Vault.
+        """
+        provider_certificate, private_key = self._tls_certificates_acme.get_assigned_certificate(
+            certificate_request=self._certificate_request_attributes
+        )
+        if not provider_certificate:
+            logger.debug("No intermediate CA certificate available for Vault ACME")
+        if not private_key:
+            logger.debug("No private key available for Vault ACME")
+        return provider_certificate, private_key
+
+    def _configure_intermediate_ca_certificate(self) -> None:
+        certificate_from_provider, private_key = self._get_acme_intermediate_ca_from_relation()
+        if not certificate_from_provider or not private_key:
+            raise ManagerError("No intermediate CA certificate available for Vault ACME")
+
+        vault_service_ca_certificate = get_vault_service_ca_certificate(
+            self._vault_client, self._mount_point
+        )
+        if (
+            vault_service_ca_certificate
+            and vault_service_ca_certificate == certificate_from_provider.certificate
+        ):
+            current_ttl = self._vault_client.get_role_max_ttl(
+                role=self._role_name, mount=self._mount_point
+            )
+            if current_ttl and not self._pki_utils.intermediate_ca_exceeds_role_ttl(
+                vault_service_ca_certificate, current_ttl
+            ):
+                self._tls_certificates_acme.renew_certificate(
+                    certificate_from_provider,
+                )
+                logger.debug("Renewing ACME intermediate CA certificate")
+                raise ManagerError("Renewing ACME intermediate CA certificate")
+            logger.debug("ACME intermediate CA certificate already set")
+            raise ManagerError("ACME intermediate CA certificate already set")
+        self._vault_client.import_ca_certificate_and_key(
+            certificate=str(certificate_from_provider.certificate),
+            private_key=str(private_key),
+            mount=self._mount_point,
+        )
+
+    def _configure_acme_role(self) -> None:
+        certificate_from_provider, _ = self._get_acme_intermediate_ca_from_relation()
+        if not certificate_from_provider:
+            logger.debug("No intermediate CA certificate available for Vault ACME")
+            return
+        max_ttl = self._pki_utils.calculate_certificates_ttl(certificate_from_provider.certificate)
+        if max_ttl != self._vault_client.get_role_max_ttl(
+            role=self._role_name, mount=self._mount_point
+        ):
+            self._vault_client.create_or_update_acme_role(
+                role=self._role_name,
+                max_ttl=f"{max_ttl}s",
+                mount=self._mount_point,
+            )
+
+    def _enable_acme(self) -> None:
+        self._vault_client.write(path=f"{self._mount_point}/config/acme", data={"enabled": True})
+
+    def make_latest_acme_issuer_default(self):
+        """Make the latest issuer the default issuer."""
+        self._pki_utils.make_latest_issuer_default()
+
+    def configure(self) -> None:
+        """Configure the ACME engine in Vault."""
+        if not self._juju_facade.is_leader:
+            logger.debug("Only leader unit can configure ACME")
+            return
+        if not self._juju_facade.relation_exists(TLS_CERTIFICATES_ACME_RELATION_NAME):
+            logger.debug(
+                "No TLS relation exists to configure ACME server: `%s`",
+                TLS_CERTIFICATES_ACME_RELATION_NAME,
+            )
+            return
+        self._vault_client.enable_secrets_engine(SecretsBackend.PKI, self._mount_point)
+
+        try:
+            self._configure_intermediate_ca_certificate()
+        except ManagerError:
+            return
+
+        self._configure_acme_role()
+
+        self._vault_client.tune_pki_backend(
+            mount=self._mount_point,
+        )
+        self._vault_client.set_urls(
+            issuing_certificates=[f"{self._vault_address}/v1/pki/ca"],
+            crl_distribution_points=[f"{self._vault_address}/v1/pki/crl"],
+            mount=self._mount_point,
+        )
+        self._vault_client.write(
+            path=f"{self._mount_point}/config/cluster",
+            data={"path": f"{self._vault_address}/v1/{self._mount_point}"},
+        )
+        self._enable_acme()
+        self.make_latest_acme_issuer_default()

--- a/machine/tests/unit/fixtures.py
+++ b/machine/tests/unit/fixtures.py
@@ -9,6 +9,7 @@ import pytest
 from charms.data_platform_libs.v0.s3 import S3Requirer
 from vault.vault_client import VaultClient
 from vault.vault_managers import (
+    ACMEManager,
     AutounsealProviderManager,
     AutounsealRequirerManager,
     BackupManager,
@@ -16,7 +17,6 @@ from vault.vault_managers import (
     PKIManager,
     RaftManager,
     TLSManager,
-    ACMEManager,
 )
 
 from charm import VaultOperatorCharm

--- a/machine/tests/unit/fixtures.py
+++ b/machine/tests/unit/fixtures.py
@@ -16,6 +16,7 @@ from vault.vault_managers import (
     PKIManager,
     RaftManager,
     TLSManager,
+    ACMEManager,
 )
 
 from charm import VaultOperatorCharm
@@ -42,6 +43,9 @@ class VaultCharmFixtures:
             ).return_value
             self.mock_pki_manager = stack.enter_context(
                 patch("charm.PKIManager", autospec=PKIManager)
+            ).return_value
+            self.mock_acme_manager = stack.enter_context(
+                patch("charm.ACMEManager", autospec=ACMEManager)
             ).return_value
             self.mock_s3_requirer = stack.enter_context(
                 patch("charm.S3Requirer", autospec=S3Requirer)

--- a/machine/tests/unit/fixtures.py
+++ b/machine/tests/unit/fixtures.py
@@ -55,7 +55,7 @@ class VaultCharmFixtures:
             ).return_value
 
             self.mock_socket_fqdn = stack.enter_context(patch("socket.getfqdn"))
-            self.mock_pki_requirer_get_assigned_certificate = stack.enter_context(
+            self.mock_get_requirer_assigned_certificate = stack.enter_context(
                 patch("charm.TLSCertificatesRequiresV4.get_assigned_certificate")
             )
             self.mock_pki_requirer_renew_certificate = stack.enter_context(

--- a/machine/tests/unit/test_charm_collect_status.py
+++ b/machine/tests/unit/test_charm_collect_status.py
@@ -14,7 +14,7 @@ from tests.unit.fixtures import VaultCharmFixtures
 
 
 class TestCharmCollectUnitStatus(VaultCharmFixtures):
-    def test_given_tls_relation_and_bad_common_name_when_collect_unit_status_then_status_is_blocked(
+    def test_given_pki_tls_relation_and_bad_common_name_when_collect_unit_status_then_status_is_blocked(
         self,
     ):
         tls_relation = testing.Relation(
@@ -30,6 +30,24 @@ class TestCharmCollectUnitStatus(VaultCharmFixtures):
 
         assert state_out.unit_status == BlockedStatus(
             "Common name is not set in the charm config, cannot configure PKI secrets engine"
+        )
+
+    def test_given_acme_tls_relation_and_bad_common_name_when_collect_unit_status_then_status_is_blocked(
+        self,
+    ):
+        tls_relation = testing.Relation(
+            endpoint="tls-certificates-acme",
+            interface="tls-certificates",
+        )
+        state_in = testing.State(
+            config={"common_name": ""},
+            relations=[tls_relation],
+        )
+
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
+
+        assert state_out.unit_status == BlockedStatus(
+            "Common name is not set in the charm config, cannot configure ACME server"
         )
 
     def test_given_peer_relation_not_created_when_collect_unit_status_then_status_is_waiting(self):

--- a/machine/tests/unit/test_charm_configure.py
+++ b/machine/tests/unit/test_charm_configure.py
@@ -157,7 +157,7 @@ class TestCharmConfigure(VaultCharmFixtures):
             relation_id=pki_relation.id,
             validity=timedelta(hours=24),
         )
-        self.mock_pki_requirer_get_assigned_certificate.return_value = (
+        self.mock_get_requirer_assigned_certificate.return_value = (
             provider_certificate,
             private_key,
         )

--- a/machine/tests/unit/test_charm_configure.py
+++ b/machine/tests/unit/test_charm_configure.py
@@ -166,6 +166,61 @@ class TestCharmConfigure(VaultCharmFixtures):
 
         self.mock_pki_manager.configure.assert_called_once()
 
+    # ACME
+    def test_given_certificate_available_when_configure_then_acme_server_is_configured(
+        self,
+    ):
+        self.mock_vault.configure_mock(
+            **{
+                "is_api_available.return_value": True,
+                "authenticate.return_value": True,
+                "is_initialized.return_value": True,
+                "is_sealed.return_value": False,
+                "is_active_or_standby.return_value": True,
+                "get_intermediate_ca.return_value": "",
+                "is_common_name_allowed_in_pki_role.return_value": False,
+            },
+        )
+        self.mock_autounseal_requires_get_details.return_value = None
+        self.mock_machine.pull.return_value = StringIO("")
+        peer_relation = testing.PeerRelation(
+            endpoint="vault-peers",
+        )
+        acme_relation = testing.Relation(
+            endpoint="tls-certificates-acme",
+            interface="tls-certificates",
+        )
+        approle_secret = testing.Secret(
+            label="vault-approle-auth-details",
+            tracked_content={"role-id": "role id", "secret-id": "secret id"},
+        )
+        state_in = testing.State(
+            unit_status=testing.ActiveStatus(),
+            leader=True,
+            secrets=[approle_secret],
+            relations=[peer_relation, acme_relation],
+            config={"common_name": "myhostname.com"},
+            networks={
+                testing.Network(
+                    "vault-peers",
+                    bind_addresses=[testing.BindAddress([testing.Address("1.2.1.2")])],
+                )
+            },
+        )
+        provider_certificate, private_key = generate_example_provider_certificate(
+            common_name="myhostname.com",
+            relation_id=acme_relation.id,
+            validity=timedelta(hours=24),
+        )
+        self.mock_get_requirer_assigned_certificate.return_value = (
+            provider_certificate,
+            private_key,
+        )
+
+        self.ctx.run(self.ctx.on.config_changed(), state_in)
+
+        self.mock_acme_manager.configure.assert_called_once()
+
     # Test Auto unseal
 
     @patch("ops.model.Model.get_binding")


### PR DESCRIPTION
# Description

- Feature manager for ACME is added
- A new TLS integration is added to get the intermediate CA for ACME
- ACME is enabled when the integration is created
- Added unit and integration tests
- Change done in both k8s and machine

To test:
- Deploy vault and self-signed-certificates
- Do the necessary steps to get vault to the active status (init and unseal)
- Integrate with the tls provider through the `tls-certificates-acme` integration
Now ACME should be enabled, use your favorite client to test (for example lego cli)

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of any required library.
