### PR TITLE
fix: Disable publishing Allure reports from forks

### DIFF
--- a/.github/workflows/k8s-integration-test.yaml
+++ b/.github/workflows/k8s-integration-test.yaml
@@ -125,7 +125,7 @@ jobs:
           allure_results: allure-results
       - name: Publish test report
         uses: peaceiris/actions-gh-pages@v4
-        if: always()
+        if: ${{ github.repository == 'canonical/vault-k8s-operator' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages


### PR DESCRIPTION
# Description

This PR prevents publishing the Allure reports from forks. This is required because the `GITHUB_TOKEN` required to do so will not have the `write` permission when the PR is from a fork, preventing the CI from passing.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
