### PR TITLE
fix: Prevent Allure report issues from failing CI

### DIFF
--- a/.github/workflows/k8s-integration-test.yaml
+++ b/.github/workflows/k8s-integration-test.yaml
@@ -119,13 +119,15 @@ jobs:
       - name: Build test report
         uses: simple-elf/allure-report-action@v1.12
         if: always()
+        continue-on-error: true
         with:
           gh_pages: gh-pages
           allure_history: allure-history
           allure_results: allure-results
       - name: Publish test report
         uses: peaceiris/actions-gh-pages@v4
-        if: ${{ github.repository == 'canonical/vault-k8s-operator' }}
+        if: always()
+        continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages


### PR DESCRIPTION
# Description

Previous PR #661 tried to prevent the Allure report from being published when a PR was opened from a fork, as the token does not have write permissions. However, it did not work.

After reading the documentation for GitHub actions more, there does not seem to be an easy way to identify a PR that comes from a fork:

- We can identify the actor that originally triggered the action, but we would have to compare against the current list of users with write access.
- We could also check the `GITHUB_TOKEN` permissions, but it would add complex code that could be fragile.

Instead, I decided to implement the simplest solution, to allow the Allure report to fail without failing the CI.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
