### PR TITLE
feat: Expose the sign-verbatim endpoint

### DIFF
--- a/k8s/charmcraft.yaml
+++ b/k8s/charmcraft.yaml
@@ -389,6 +389,12 @@ config:
       description: >-
         This value specifies the L (Locality) value in the Subject field of the certificate issued by Vault PKI.
         If not set the issued certificate will not have an L value in the Subject field.
+    pki_sign_verbatim:
+      type: boolean
+      default: false
+      description: >-
+        If set to true, all other pki configuration options will be ignored and the Vault charm will sign the certificate verbatim.
+        Using this option is not recommended and should only be done when the requirers are trusted.
 
 # ACME engine options
     acme_ca_common_name:

--- a/k8s/charmcraft.yaml
+++ b/k8s/charmcraft.yaml
@@ -394,7 +394,8 @@ config:
       default: false
       description: >-
         If set to true, all other pki configuration options will be ignored and the Vault charm will sign the certificate verbatim.
-        Using this option is not recommended and should only be done when the requirers are trusted.
+        Vault recommends not using this option unless requirers are trusted.
+        "This is a potentially dangerous endpoint and only highly trusted users should have access."
 
 # ACME engine options
     acme_ca_common_name:

--- a/k8s/lib/vault/vault_client.py
+++ b/k8s/lib/vault/vault_client.py
@@ -425,12 +425,12 @@ class VaultClient:
         """
         try:
             response = self._client.secrets.pki.sign_certificate(
-            csr=csr,
-            mount_point=mount,
-            common_name=common_name,
-            name=role,
-            extra_params={"ttl": ttl},
-        )
+                csr=csr,
+                mount_point=mount,
+                common_name=common_name,
+                name=role,
+                extra_params={"ttl": ttl},
+            )
             logger.info("Signed a PKI certificate for %s", common_name)
             return Certificate(
                 certificate=response["data"]["certificate"],
@@ -440,7 +440,7 @@ class VaultClient:
         except InvalidRequest as e:
             logger.warning("Error while signing PKI certificate: %s", e)
             return None
-    
+
     def sign_pki_certificate_signing_request_verbatim(
         self,
         mount: str,
@@ -479,7 +479,7 @@ class VaultClient:
             )
         except InvalidRequest as e:
             logger.warning("Error while signing PKI certificate: %s", e)
-            return None    
+            return None
 
     def create_or_update_pki_charm_role(
         self,

--- a/k8s/lib/vault/vault_client.py
+++ b/k8s/lib/vault/vault_client.py
@@ -408,6 +408,7 @@ class VaultClient:
         csr: str,
         common_name: str,
         ttl: str,
+        verbatim: bool = False,
     ) -> Certificate | None:
         """Sign a certificate signing request for the PKI backend.
 
@@ -424,7 +425,14 @@ class VaultClient:
             Certificate: The signed certificate object
         """
         try:
-            response = self._client.secrets.pki.sign_certificate(
+            if verbatim:
+                response = self._client.secrets.pki.sign_verbatim(
+                    csr=csr,
+                    mount_point=mount,
+                    name=role,
+                )
+            else:
+                response = self._client.secrets.pki.sign_certificate(
                 csr=csr,
                 mount_point=mount,
                 common_name=common_name,

--- a/k8s/lib/vault/vault_managers.py
+++ b/k8s/lib/vault/vault_managers.py
@@ -1176,7 +1176,12 @@ class PKIManager:
             csr=str(requirer_csr.certificate_signing_request),
             common_name=requirer_csr.certificate_signing_request.common_name,
             ttl=f"{allowed_cert_validity}s",
-            verbatim=self._sign_verbatim,
+        ) if not self._sign_verbatim else self._vault_client.sign_pki_certificate_signing_request_verbatim(
+            mount=self._mount_point,
+            role=self._role_name,
+            csr=str(requirer_csr.certificate_signing_request),
+            common_name=requirer_csr.certificate_signing_request.common_name,
+            ttl=f"{allowed_cert_validity}s",
         )
         if not certificate:
             logger.debug("Failed to sign the certificate")

--- a/k8s/lib/vault/vault_managers.py
+++ b/k8s/lib/vault/vault_managers.py
@@ -983,6 +983,7 @@ class PKIManager:
         locality: str | None,
         vault_pki: TLSCertificatesProvidesV4,
         tls_certificates_pki: TLSCertificatesRequiresV4,
+        sign_verbatim: bool | None,
     ):
         """Create a new PKIManager object.
 
@@ -1031,6 +1032,7 @@ class PKIManager:
         self._country = country if country is not None else None
         self._province = province if province is not None else None
         self._locality = locality if locality is not None else None
+        self._sign_verbatim = sign_verbatim if sign_verbatim is not None else False
 
     def _get_pki_intermediate_ca_from_relation(
         self,
@@ -1102,7 +1104,7 @@ class PKIManager:
             certificate_from_provider.certificate
         )
 
-        if not self._vault_client.role_config_matches_given_config(
+        if not self._sign_verbatim and not self._vault_client.role_config_matches_given_config(
             role=self._role_name,
             mount=self._mount_point,
             allowed_domains=self._allowed_domains_list,
@@ -1174,6 +1176,7 @@ class PKIManager:
             csr=str(requirer_csr.certificate_signing_request),
             common_name=requirer_csr.certificate_signing_request.common_name,
             ttl=f"{allowed_cert_validity}s",
+            verbatim=self._sign_verbatim,
         )
         if not certificate:
             logger.debug("Failed to sign the certificate")

--- a/k8s/src/charm.py
+++ b/k8s/src/charm.py
@@ -689,6 +689,7 @@ class VaultCharm(CharmBase):
             country=self.juju_facade.get_string_config("pki_country"),
             province=self.juju_facade.get_string_config("pki_province"),
             locality=self.juju_facade.get_string_config("pki_locality"),
+            sign_verbatim=self.juju_facade.get_bool_config("pki_sign_verbatim"),
         )
         manager.sync()
 

--- a/k8s/src/charm.py
+++ b/k8s/src/charm.py
@@ -504,6 +504,7 @@ class VaultCharm(CharmBase):
             country=self.juju_facade.get_string_config("pki_country"),
             province=self.juju_facade.get_string_config("pki_province"),
             locality=self.juju_facade.get_string_config("pki_locality"),
+            sign_verbatim=self.juju_facade.get_bool_config("pki_sign_verbatim"),
         )
         manager.configure()
 

--- a/k8s/tests/unit/lib/test_vault_managers.py
+++ b/k8s/tests/unit/lib/test_vault_managers.py
@@ -391,6 +391,7 @@ class TestPKIManager:
             country=self.country,
             province=self.province,
             locality=self.locality,
+            sign_verbatim=False,
         )
 
     @pytest.fixture


### PR DESCRIPTION
# Description

**Note**: This PR is work in progress as it lacks tests. For now the purpose is to get feedback from the team whether to continue or not.

This PR exposes the [sign-verbatim](https://developer.hashicorp.com/vault/api-docs/secret/pki#sign-verbatim) endpoint of Vault. The users will be able to configure Vault PKI to allow sign-verbatim through a charm config option. When set to true no other PKI configs are considered or needed. This will make Vault PKI sign the CSR as is with all its attributes.
Vault discourages using this endpoint it says: "This is a potentially dangerous endpoint and only highly trusted users should have access."

### Motivation:
Some users want to have a certificate that matches their csr when using Vault as a cert provider. By default Vault will not respect the subject name attributes from the csr (organization, organizational unit, country...) and will use those as configured in the PKI role.
Sign verbatim will generate a certificate that includes those fields just like they were requested in the CSR.

### Risk:
- Requirers can abuse this and ask for values that shouldn't be allowed, for example the requirer asks for an org that doesn't match their actual org, Vault can't validate that.
- Reverting this change in the future would be a breaking change for the API

### Opinion:
The default value of this config is false and we have a clear warning copied from the Vault docs in our charmcraft.yaml. If the operator decides to set this to true despite the warning they probably know what they are doing and it won't be any less secure than a solution like `self-signed-certificates` that does exactly that.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
