### PR TITLE
docs: adapt docs to Vault 1.17

### DIFF
--- a/docs/how-to/scale_k8s.md
+++ b/docs/how-to/scale_k8s.md
@@ -14,8 +14,8 @@ Run `juju status`:
 Model  Controller          Cloud/Region        Version  SLA          Timestamp
 demo   microk8s-localhost  microk8s/localhost  3.4.0    unsupported  12:52:32-04:00
 
-App    Version  Status   Scale  Charm      Channel    Rev  Address         Exposed  Message
-vault           waiting      1  vault-k8s  1.15/beta  198  10.152.183.208  no       installing agent
+App    Version  Status   Scale  Charm      Channel      Rev  Address         Exposed  Message
+vault           waiting      1  vault-k8s  1.17/stable  198  10.152.183.208  no       installing agent
 
 Unit      Workload  Agent  Address      Ports  Message
 vault/0*  active    idle   10.1.182.38
@@ -35,8 +35,8 @@ The new units will be sealed:
 Model  Controller          Cloud/Region        Version  SLA          Timestamp
 demo   microk8s-localhost  microk8s/localhost  3.4.0    unsupported  12:54:51-04:00
 
-App    Version  Status   Scale  Charm      Channel    Rev  Address         Exposed  Message
-vault           waiting      3  vault-k8s  1.15/beta  198  10.152.183.208  no       installing agent
+App    Version  Status   Scale  Charm      Channel      Rev  Address         Exposed  Message
+vault           waiting      3  vault-k8s  1.17/stable  198  10.152.183.208  no       installing agent
 
 Unit      Workload  Agent  Address      Ports  Message
 vault/0*  active    idle   10.1.182.38         
@@ -77,8 +77,8 @@ $ juju status
 Model  Controller          Cloud/Region        Version  SLA          Timestamp
 demo   microk8s-localhost  microk8s/localhost  3.4.0    unsupported  12:57:52-04:00
 
-App    Version  Status  Scale  Charm      Channel    Rev  Address         Exposed  Message
-vault           active      3  vault-k8s  1.15/beta  198  10.152.183.208  no       
+App    Version  Status  Scale  Charm      Channel      Rev  Address         Exposed  Message
+vault           active      3  vault-k8s  1.17/stable  198  10.152.183.208  no       
 
 Unit      Workload  Agent  Address      Ports  Message
 vault/0*  active    idle   10.1.182.38         

--- a/docs/how-to/scale_machine.md
+++ b/docs/how-to/scale_machine.md
@@ -14,8 +14,8 @@ Run `juju status`:
 Model  Controller           Cloud/Region         Version  SLA          Timestamp
 demo   localhost-localhost  localhost/localhost  3.4.0    unsupported  12:11:19-04:00
 
-App    Version  Status  Scale  Charm  Channel    Rev  Exposed  Message
-vault           active      1  vault  1.15/beta  257  no       
+App    Version  Status  Scale  Charm  Channel      Rev  Exposed  Message
+vault           active      1  vault  1.17/stable  257  no       
 
 Unit      Workload  Agent  Machine  Public address  Ports  Message
 vault/0*  active    idle   0        10.191.126.116         
@@ -38,8 +38,8 @@ The new units will be sealed:
 Model  Controller           Cloud/Region         Version  SLA          Timestamp
 demo   localhost-localhost  localhost/localhost  3.4.0    unsupported  12:19:14-04:00
 
-App    Version  Status   Scale  Charm  Channel    Rev  Exposed  Message
-vault           blocked      3  vault  1.15/beta  257  no       Waiting for Vault to be unsealed
+App    Version  Status   Scale  Charm  Channel      Rev  Exposed  Message
+vault           blocked      3  vault  1.17/stable  257  no       Waiting for Vault to be unsealed
 
 Unit      Workload  Agent  Machine  Public address  Ports  Message
 vault/0*  active    idle   0        10.191.126.116         
@@ -79,8 +79,8 @@ $ juju status
 Model  Controller           Cloud/Region         Version  SLA          Timestamp
 demo   localhost-localhost  localhost/localhost  3.4.0    unsupported  12:24:32-04:00
 
-App    Version  Status  Scale  Charm  Channel    Rev  Exposed  Message
-vault           active      3  vault  1.15/beta  257  no       
+App    Version  Status  Scale  Charm  Channel      Rev  Exposed  Message
+vault           active      3  vault  1.17/stable  257  no       
 
 Unit      Workload  Agent  Machine  Public address  Ports  Message
 vault/0*  active    idle   0        10.191.126.116         

--- a/docs/how-to/unseal_k8s.md
+++ b/docs/how-to/unseal_k8s.md
@@ -8,8 +8,8 @@ $ juju status
 Model  Controller          Cloud/Region        Version  SLA          Timestamp
 demo   microk8s-localhost  microk8s/localhost  3.4.0    unsupported  13:02:12-04:00
 
-App    Version  Status   Scale  Charm      Channel    Rev  Address         Exposed  Message
-vault           waiting      3  vault-k8s  1.15/beta  198  10.152.183.208  no       installing agent
+App    Version  Status   Scale  Charm      Channel      Rev  Address         Exposed  Message
+vault           waiting      3  vault-k8s  1.17/stable  198  10.152.183.208  no       installing agent
 
 Unit      Workload  Agent  Address      Ports  Message
 vault/0*  active    idle   10.1.182.38         
@@ -36,8 +36,8 @@ $ juju status
 Model  Controller          Cloud/Region        Version  SLA          Timestamp
 demo   microk8s-localhost  microk8s/localhost  3.4.0    unsupported  13:03:26-04:00
 
-App    Version  Status  Scale  Charm      Channel    Rev  Address         Exposed  Message
-vault           active      3  vault-k8s  1.15/beta  198  10.152.183.208  no       
+App    Version  Status  Scale  Charm      Channel      Rev  Address         Exposed  Message
+vault           active      3  vault-k8s  1.17/stable  198  10.152.183.208  no       
 
 Unit      Workload  Agent  Address      Ports  Message
 vault/0*  active    idle   10.1.182.38         

--- a/docs/how-to/unseal_machine.md
+++ b/docs/how-to/unseal_machine.md
@@ -8,8 +8,8 @@ $ juju status
 Model  Controller           Cloud/Region         Version  SLA          Timestamp
 demo   localhost-localhost  localhost/localhost  3.4.0    unsupported  12:34:35-04:00
 
-App    Version  Status   Scale  Charm  Channel    Rev  Exposed  Message
-vault           blocked      3  vault  1.15/beta  257  no       Waiting for Vault to be unsealed
+App    Version  Status   Scale  Charm  Channel      Rev  Exposed  Message
+vault           blocked      3  vault  1.17/stable  257  no       Waiting for Vault to be unsealed
 
 Unit      Workload  Agent  Machine  Public address  Ports  Message
 vault/0*  active    idle   0        10.191.126.116         
@@ -40,8 +40,8 @@ The units will go back to the active/idle state:
 $ juju status
 demo   localhost-localhost  localhost/localhost  3.4.0    unsupported  12:39:11-04:00
 
-App    Version  Status  Scale  Charm  Channel    Rev  Exposed  Message
-vault           active      3  vault  1.15/beta  257  no       
+App    Version  Status  Scale  Charm  Channel      Rev  Exposed  Message
+vault           active      3  vault  1.17/stable  257  no       
 
 Unit      Workload  Agent  Machine  Public address  Ports  Message
 vault/0*  active    idle   0        10.191.126.116         

--- a/docs/tutorial/getting_started_k8s.md
+++ b/docs/tutorial/getting_started_k8s.md
@@ -27,7 +27,7 @@ sudo microk8s enable dns
 From your terminal, install Juju:
 
 ```
-sudo snap install juju --channel=3.4/stable
+sudo snap install juju --channel=3.6/stable
 ```
 
 Bootstrap a Juju controller:
@@ -47,7 +47,7 @@ juju add-model demo
 Deploy the Vault K8s operator:
 
 ```shell
-juju deploy vault-k8s vault --channel=1.16/edge
+juju deploy vault-k8s vault --channel=1.17/stable
 ```
 
 Deploying Vault will take several minutes, wait for the unit to be in the `blocked/idle` state, awaiting initialisation.
@@ -58,10 +58,10 @@ Model  Controller          Cloud/Region        Version  SLA          Timestamp
 demo   microk8s-localhost  microk8s/localhost  3.4.0    unsupported  12:31:45-04:00
 
 App    Version  Status   Scale  Charm      Channel    Rev  Address         Exposed  Message
-vault                    waiting      1  vault-k8s  1.15/beta  198  10.152.183.204  no       installing agent
+vault           blocked      1  vault-k8s  1.18/edge  380  10.152.183.183  no       Please initialize Vault or integrate with an auto-unseal provider
 
-Unit      Workload  Agent  Address      Ports  Message
-vault/0*  blocked   idle   10.1.182.56         Please initialize Vault
+Unit      Workload  Agent  Address     Ports  Message
+vault/0*  blocked   idle   10.1.0.237         Please initialize Vault or integrate with an auto-unseal provider
 ```
 
 ## 4. Set up the Vault CLI

--- a/docs/tutorial/getting_started_machine.md
+++ b/docs/tutorial/getting_started_machine.md
@@ -34,7 +34,7 @@ juju add-model demo
 Deploy the Vault operator:
 
 ```shell
-juju deploy vault --channel=1.15/beta
+juju deploy vault --channel=1.17/stable
 ```
 
 Deploying Vault will take several minutes, wait for the unit to be in the `blocked/idle` state, awaiting initialisation.
@@ -44,14 +44,14 @@ $ juju status
 Model  Controller           Cloud/Region         Version  SLA          Timestamp
 demo   localhost-localhost  localhost/localhost  3.4.0    unsupported  11:41:15-04:00
 
-App    Version  Status   Scale  Charm  Channel    Rev  Exposed  Message
-vault           blocked      1  vault  1.15/beta  257  no       Waiting for Vault to be initialized
+App    Version  Status   Scale  Charm  Channel      Rev  Exposed  Message
+vault           blocked      1  vault  1.17/stable  475  no       Please initialize Vault or integrate with an auto-unseal provider
 
 Unit      Workload  Agent  Machine  Public address  Ports  Message
-vault/0*  blocked   idle   0        10.191.126.116         Waiting for Vault to be initialized
+vault/0*  blocked   idle   0        10.102.71.106          Please initialize Vault or integrate with an auto-unseal provider
 
-Machine  State    Address         Inst id        Base          AZ  Message
-0        started  10.191.126.116  juju-b8368f-0  ubuntu@22.04      Running
+Machine  State    Address        Inst id        Base          AZ  Message
+0        started  10.102.71.106  juju-c3e914-0  ubuntu@24.04      Running
 ```
 
 ## 4. Set up the Vault CLI
@@ -106,7 +106,7 @@ Total Shares       0
 Threshold          0
 Unseal Progress    0/0
 Unseal Nonce       n/a
-Version            1.15.4
+Version            1.17.6
 Build Date         n/a
 Storage Type       raft
 HA Enabled         true


### PR DESCRIPTION
# Description

Now that we version our documentation, it is important that the doc version on `release-1.17` represent the code on that same branch. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
