### PR TITLE
docs: remove duplicate menu item for scaling

### DIFF
--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -9,8 +9,6 @@ Day-1 operations cover the deployment and integration of the Vault charm.
 ```{toctree}
 :maxdepth: 1
 
-scale_k8s
-scale_machine
 unseal_k8s
 unseal_machine
 use_behind_ingress_k8s


### PR DESCRIPTION
# Description

The "scale (k8s)" and "scale (machine)" showed up twice in the left hand menu under how-to and that was because it was listed twice in the toc block in the docs , both under day-1 and day-2 operations. Here we remove this instance under day-1. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
