### PR TITLE
fix: Configure haproxy with a hostname that is accepted in the integration tests

### DIFF
--- a/machine/tests/integration/test_ingress.py
+++ b/machine/tests/integration/test_ingress.py
@@ -73,7 +73,7 @@ async def test_given_haproxy_deployed_when_integrated_then_status_is_active(
     assert ops_test.model
 
     haproxy_app = ops_test.model.applications[HAPROXY_APPLICATION_NAME]
-    external_hostname = "haproxy"
+    external_hostname = "haproxy.example.com"
     await haproxy_app.set_config({"external-hostname": external_hostname})
 
     await ops_test.model.integrate(


### PR DESCRIPTION
# Description

The CI is failing due to a breaking change in ha-proxy that now has extra validation on the hostname. We fix the tests to use a valid hostname.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
