### PR TITLE
fix: Block charm when vault-pki relation created but tls-certificates-pki is missing

### DIFF
--- a/k8s/src/charm.py
+++ b/k8s/src/charm.py
@@ -253,6 +253,14 @@ class VaultCharm(CharmBase):
                     )
                 )
                 return
+        if self.juju_facade.relation_exists(PKI_RELATION_NAME):
+            if not self.juju_facade.relation_exists(TLS_CERTIFICATES_PKI_RELATION_NAME):
+                event.add_status(
+                    BlockedStatus(
+                        f"{TLS_CERTIFICATES_PKI_RELATION_NAME} relation is missing, cannot configure PKI secrets engine"
+                    )
+                )
+                return
         if self.juju_facade.relation_exists(TLS_CERTIFICATES_PKI_RELATION_NAME):
             if not common_name_config_is_valid(
                 self.juju_facade.get_string_config("pki_ca_common_name")

--- a/k8s/tests/unit/test_charm_collect_status.py
+++ b/k8s/tests/unit/test_charm_collect_status.py
@@ -21,6 +21,24 @@ class TestCharmCollectUnitStatus(VaultCharmFixtures):
 
         assert state_out.unit_status == BlockedStatus("log_level config is not valid")
 
+    def test_given_pki_relation_and_tls_certificates_pki_relation_missing_when_collect_unit_status_then_status_is_blocked(
+        self,
+    ):
+        pki_relation = testing.Relation(
+            endpoint="vault-pki",
+            interface="tls-certificates",
+        )
+        state_in = testing.State(
+            config={"pki_ca_common_name": "domain.com"},
+            relations=[pki_relation],
+        )
+
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
+
+        assert state_out.unit_status == BlockedStatus(
+            "tls-certificates-pki relation is missing, cannot configure PKI secrets engine"
+        )
+
     def test_given_cant_connect_when_collect_unit_status_then_status_is_waiting(self):
         container = testing.Container(
             name="vault",

--- a/machine/src/charm.py
+++ b/machine/src/charm.py
@@ -431,6 +431,14 @@ class VaultOperatorCharm(CharmBase):
                     )
                 )
                 return
+        if self.juju_facade.relation_exists(PKI_RELATION_NAME):
+            if not self.juju_facade.relation_exists(TLS_CERTIFICATES_PKI_RELATION_NAME):
+                event.add_status(
+                    BlockedStatus(
+                        f"{TLS_CERTIFICATES_PKI_RELATION_NAME} relation is missing, cannot configure PKI secrets engine"
+                    )
+                )
+                return
         if self.juju_facade.relation_exists(TLS_CERTIFICATES_PKI_RELATION_NAME):
             if not common_name_config_is_valid(
                 self.juju_facade.get_string_config("pki_ca_common_name")

--- a/machine/tests/unit/test_charm_collect_status.py
+++ b/machine/tests/unit/test_charm_collect_status.py
@@ -24,6 +24,24 @@ class TestCharmCollectUnitStatus(VaultCharmFixtures):
 
         assert state_out.unit_status == BlockedStatus("log_level config is not valid")
 
+    def test_given_pki_relation_and_tls_certificates_pki_relation_missing_when_collect_unit_status_then_status_is_blocked(
+        self,
+    ):
+        pki_relation = testing.Relation(
+            endpoint="vault-pki",
+            interface="tls-certificates",
+        )
+        state_in = testing.State(
+            config={"pki_ca_common_name": "domain.com"},
+            relations=[pki_relation],
+        )
+
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
+
+        assert state_out.unit_status == BlockedStatus(
+            "tls-certificates-pki relation is missing, cannot configure PKI secrets engine"
+        )
+
     def test_given_pki_tls_relation_and_bad_common_name_when_collect_unit_status_then_status_is_blocked(
         self,
     ):


### PR DESCRIPTION
# Description

Fixes #686 
This PR prevents Vault from going to active status when `vault-pki` relation is create while the `tls-certificates-pki` integration to a root CA provider is missing. The charm goes to blocked instead giving the user a feedback that the `pki` engine has not been fully configured yet.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
