### PR TITLE
fix: Add the CA to the set instead of converting the string itself to a set

### DIFF
--- a/k8s/.vendored/vault-package/vault/vault_managers.py
+++ b/k8s/.vendored/vault-package/vault/vault_managers.py
@@ -438,7 +438,7 @@ class TLSManager(Object):
         if ca := self.pull_tls_file_from_workload(File.CA):
             for relation in self.juju_facade.get_relations(SEND_CA_CERT_RELATION_NAME):
                 self.certificate_transfer.add_certificates(
-                    certificates=set(ca), relation_id=relation.id
+                    certificates={ca}, relation_id=relation.id
                 )
                 logger.info("Sent CA certificate to relation %s", relation.id)
         else:

--- a/k8s/tests/unit/lib/test_vault_tls.py
+++ b/k8s/tests/unit/lib/test_vault_tls.py
@@ -736,7 +736,7 @@ class TestCharmTLS:
             self.ctx.run(self.ctx.on.relation_joined(cert_transfer_relation), state_in)
 
             add_certificates.assert_called_once_with(
-                certificates=set("some ca"),
+                certificates={"some ca"},
                 relation_id=cert_transfer_relation.id,
             )
 

--- a/machine/.vendored/vault-package/vault/vault_managers.py
+++ b/machine/.vendored/vault-package/vault/vault_managers.py
@@ -438,7 +438,7 @@ class TLSManager(Object):
         if ca := self.pull_tls_file_from_workload(File.CA):
             for relation in self.juju_facade.get_relations(SEND_CA_CERT_RELATION_NAME):
                 self.certificate_transfer.add_certificates(
-                    certificates=set(ca), relation_id=relation.id
+                    certificates={ca}, relation_id=relation.id
                 )
                 logger.info("Sent CA certificate to relation %s", relation.id)
         else:

--- a/vault-package/vault/vault_managers.py
+++ b/vault-package/vault/vault_managers.py
@@ -438,7 +438,7 @@ class TLSManager(Object):
         if ca := self.pull_tls_file_from_workload(File.CA):
             for relation in self.juju_facade.get_relations(SEND_CA_CERT_RELATION_NAME):
                 self.certificate_transfer.add_certificates(
-                    certificates=set(ca), relation_id=relation.id
+                    certificates={ca}, relation_id=relation.id
                 )
                 logger.info("Sent CA certificate to relation %s", relation.id)
         else:


### PR DESCRIPTION
# Description

Fixes #705 `set("abc")` will result in `{'a', 'b', 'c'}` this PR fixes that bug.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
