### PR TITLE
build(fix): configure uv.lock locations for trivy workflow

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -4,7 +4,15 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:  # Allows manual triggering
+
 
 jobs:
-  scan:
+  scan-k8s:
     uses: canonical/identity-credentials-workflows/.github/workflows/uv-scan.yaml@v0
+    with:
+      uv-lock-path: './k8s/uv.lock'
+  scan-machine:
+    uses: canonical/identity-credentials-workflows/.github/workflows/uv-scan.yaml@v0
+    with:
+      uv-lock-path: './machine/uv.lock'


### PR DESCRIPTION
# Description

Splits the trivy workflow into two separate jobs (one for k8s, one for machine charm) and tells it where to find the `uv.lock` file.

I haven't tested this yet, but once this is merged I can test fixes before merge (due to the `workflow_dispatch` addition)

- [x] ~~Needs https://github.com/canonical/identity-credentials-workflows/pull/39~~

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
