### PR TITLE
build: Linkcheck ignore developer.hashicorp links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+
 import yaml
 
 # Configuration for the Sphinx documentation builder.
@@ -226,8 +227,9 @@ redirects = {}
 
 linkcheck_ignore = [
     "http://127.0.0.1:8000",
+    "https://developer.hashicorp.com/*",
     "https://github.com/canonical/ACME/*",
-    r"https://matrix.to/#/#tls:ubuntu\.com"
+    r"https://matrix.to/#/#tls:ubuntu\.com",
 ]
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'
@@ -349,5 +351,8 @@ if os.path.exists('./reuse/substitutions.yaml'):
 # Add configuration for intersphinx mapping
 
 intersphinx_mapping = {
-    'starter-pack': ('https://canonical-example-product-documentation.readthedocs-hosted.com/en/latest', None)
+    "starter-pack": (
+        "https://canonical-example-product-documentation.readthedocs-hosted.com/en/latest",
+        None,
+    )
 }


### PR DESCRIPTION
Linkcheck keeps failing on the hashicorp docs, which are rate limiting
us.

I tried upping the number of retries -- this seems to be the only way to
wait longer between retries. It didn't work.

This is blocking several other PRs.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
