### PR TITLE
feat: Enable `juju expose` to open port for Vault access

### DIFF
--- a/k8s/.vendored/vault-package/vault/juju_facade.py
+++ b/k8s/.vendored/vault-package/vault/juju_facade.py
@@ -11,6 +11,7 @@ from ops.model import (
     Application,
     Binding,
     ModelError,
+    Port,
     Relation,
     RelationDataContent,
     RelationDataError,
@@ -79,6 +80,14 @@ class JujuFacade:
 
     def __init__(self, charm: CharmBase):
         self.charm = charm
+
+    def set_unit_ports(self, *ports: int | Port) -> None:
+        """Set the ports for the unit.
+
+        This enables Juju to open the ports in the firewall if needed when
+        `juju expose` is used.
+        """
+        return self.charm.unit.set_ports(*ports)
 
     # Secret related methods
     def get_secret(self, label: str | None = None, id: str | None = None) -> Secret:

--- a/machine/.vendored/vault-package/vault/juju_facade.py
+++ b/machine/.vendored/vault-package/vault/juju_facade.py
@@ -11,6 +11,7 @@ from ops.model import (
     Application,
     Binding,
     ModelError,
+    Port,
     Relation,
     RelationDataContent,
     RelationDataError,
@@ -79,6 +80,14 @@ class JujuFacade:
 
     def __init__(self, charm: CharmBase):
         self.charm = charm
+
+    def set_unit_ports(self, *ports: int | Port) -> None:
+        """Set the ports for the unit.
+
+        This enables Juju to open the ports in the firewall if needed when
+        `juju expose` is used.
+        """
+        return self.charm.unit.set_ports(*ports)
 
     # Secret related methods
     def get_secret(self, label: str | None = None, id: str | None = None) -> Secret:

--- a/machine/src/charm.py
+++ b/machine/src/charm.py
@@ -116,6 +116,7 @@ class VaultOperatorCharm(CharmBase):
     def __init__(self, *args: Any):
         super().__init__(*args)
         self.juju_facade = JujuFacade(self)
+        self.juju_facade.set_unit_ports(VAULT_PORT)
         self.machine = Machine()
         self._cos_agent = COSAgentProvider(
             self,

--- a/vault-package/vault/juju_facade.py
+++ b/vault-package/vault/juju_facade.py
@@ -11,6 +11,7 @@ from ops.model import (
     Application,
     Binding,
     ModelError,
+    Port,
     Relation,
     RelationDataContent,
     RelationDataError,
@@ -79,6 +80,14 @@ class JujuFacade:
 
     def __init__(self, charm: CharmBase):
         self.charm = charm
+
+    def set_unit_ports(self, *ports: int | Port) -> None:
+        """Set the ports for the unit.
+
+        This enables Juju to open the ports in the firewall if needed when
+        `juju expose` is used.
+        """
+        return self.charm.unit.set_ports(*ports)
 
     # Secret related methods
     def get_secret(self, label: str | None = None, id: str | None = None) -> Secret:


### PR DESCRIPTION
fixes #751 

Unfortunately, I wasn't able to set up an environment to test this, since this has no effect on LXD or k8s, and I wasn't having any luck configuring OpenStack.

I suggest we just trust Juju to do its thing here.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
