### PR TITLE
docs: Document backup and restore key related limitations

### DIFF
--- a/docs/how-to/create_backup.md
+++ b/docs/how-to/create_backup.md
@@ -3,13 +3,14 @@
 ## Pre-requisites
 
 To create a Vault Backup, ensure you:
+
 - Have a Vault cluster deployed.
-- Your Vault deployment is in *active idle* state.
+- Your Vault deployment is in _active idle_ state.
 - Have access to S3 storage.
 - Have [configured the settings for S3 storage](../reference/s3_storage.md).
 - Have saved your unseal keys and root-token in a secure location of your choice.
 
-**Note**: The unseal keys and root-token used at the time of creating the backup must be saved as they will be required to perform the restore action.
+**Note**: The unseal keys and root-token used at the time of creating the backup must be saved as they will be required to perform the restore action. Additionally the new Vault on which the backup will be restored must have the same key-shares and key-threshold configuration when initialized.
 
 Once the prerequisites are in place you can run the `create-backup` action on the leader unit to create a backup:
 
@@ -18,5 +19,6 @@ Once the prerequisites are in place you can run the `create-backup` action on th
 The action will create a snapshot of the Vault cluster, save it to the configured S3 storage and return the identifier of the backup.
 
 ## List backups
+
 It is possible to list all backups that are saved in the configured S3 storage using the `list-backups` action:
 `juju run vault/leader list-backups`

--- a/docs/how-to/restore_backup.md
+++ b/docs/how-to/restore_backup.md
@@ -3,13 +3,16 @@
 ## Pre-requisites
 
 To restore a Vault Backup, ensure you:
-* Have a Vault cluster deployed.
-* Your Vault deployment is in *active idle* state.
-* Have access to S3 storage where your backup is saved.
-* Have [configured the settings for S3 storage](../reference/s3_storage.md).
-* Have access to the unseal keys and root-token used by the Vault cluster at the time of creating the backup.
+
+- Have a Vault cluster deployed.
+- Have Vault initialized with the same key-shares and key-threshold as the one on which the backup was created
+- Your Vault deployment is in _active idle_ state.
+- Have access to S3 storage where your backup is saved.
+- Have [configured the settings for S3 storage](../reference/s3_storage.md).
+- Have access to the unseal keys and root-token used by the Vault cluster at the time of creating the backup.
 
 Once the prerequisites are in place you can run the `restore-backup` action on the leader unit to restore the specified backup, providing the following parameters to the action:
+
 - backup-id: Identifier of the backup you are attempting to restore, as saved on the S3 storage.
 
 `juju run vault/leader restore-backup backup-id=<backup-id> `
@@ -23,8 +26,10 @@ You can get a list of the identifiers of all the backups that are stored on the 
 `juju run vault/leader list-backups`
 
 ## Restore Backups created in different environments
+
 To restore a snapshot that wasn't created using the Vault charm's `create-backup` action, you'll need to manually upload it to the S3 storage accessible by the Vault charm where the `restore-backup` action will run.
+
 1. [Configure the settings for S3 storage](../reference/s3_storage.md).
-2.  Connect to your S3 storage
+2. Connect to your S3 storage
 3. Use the same bucket configured in step 1 to store the snapshot
 4. Use the ID of the stored snapshot to run the restore backup action


### PR DESCRIPTION
# Description

Currently the backup can be restored on a vault that had been initialised with the same key-shares and key-threshold configs as the one where the backup was taken. This is a limitation that the charm could work around, but until that is done we have to reflect the current state of things in the docs.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
