### PR TITLE
fix: Add missing config to pass content length in S3 backup generation on ceph-ragosgw

### DIFF
--- a/vault-package/vault/vault_s3.py
+++ b/vault-package/vault/vault_s3.py
@@ -78,6 +78,8 @@ class S3:
                 region_name=region,
             )
             custom_config = Config(
+                request_checksum_calculation="WHEN_REQUIRED",
+                response_checksum_validation="WHEN_REQUIRED",
                 retries={
                     "max_attempts": 1,
                 },


### PR DESCRIPTION

# Description

Add missing boto3 configuration to be able to pass content-length upon S3 upload_file/PUT command
This fixes #825 to make S3 backup work with Ceph-RadosGW

# Checklist:

- [X] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
