### PR TITLE
docs: always use -r (raw-output without quotes) in yq

### DIFF
--- a/.github/workflows/machine-integration-test.yaml
+++ b/.github/workflows/machine-integration-test.yaml
@@ -77,7 +77,7 @@ jobs:
           sudo wget --quiet --no-clobber https://dl.min.io/client/mc/release/linux-amd64/mc -O ${minio_binaries_path}/mc && sudo chmod +x ${minio_binaries_path}/mc
           sudo snap set lxd minio.path=${minio_binaries_path}
           sudo snap restart lxd
-          lxd_bridge_addr=$(sudo lxc network list --format yaml | yq '.[] | select(.name == "lxdbr0") | .config["ipv4.address"]' | cut -d'/' -f1)
+          lxd_bridge_addr=$(sudo lxc network list --format yaml | yq -r '.[] | select(.name == "lxdbr0") | .config["ipv4.address"]' | cut -d'/' -f1)
           echo "Restricting bucket access to the lxd bridge. lxd_bridge_addr=${lxd_bridge_addr}"
           sudo lxc config set core.storage_buckets_address ${lxd_bridge_addr}:8555
           echo "Waiting for Juju to react to the buckets restriction..."

--- a/docs/how-to/scale_k8s.md
+++ b/docs/how-to/scale_k8s.md
@@ -46,7 +46,7 @@ vault/2   blocked   idle   10.1.182.34         Please unseal Vault
 
 Set the `VAULT_ADDR` variable to the `vault/1` unit:
 ```
-export VAULT_ADDR=https://$(juju status vault/1 --format=yaml |  yq '.applications.vault.units.vault/1.address'):8200; echo $VAULT_ADDR
+export VAULT_ADDR=https://$(juju status vault/1 --format=yaml |  yq -r '.applications.vault.units.vault/1.address'):8200; echo $VAULT_ADDR
 ```
 
 Set the `VAULT_SKIP_VERIFY` to true:
@@ -64,7 +64,7 @@ vault operator unseal EJoB62t286mjUpSQYZg3mOla3lz/bbElVL5OLnj+rpE=
 And complete the same operations for the `vault/2` unit:
 
 ```
-export VAULT_ADDR=https://$(juju status vault/2 --format=yaml |  yq '.applications.vault.units.vault/2.address'):8200; echo $VAULT_ADDR
+export VAULT_ADDR=https://$(juju status vault/2 --format=yaml |  yq -r '.applications.vault.units.vault/2.address'):8200; echo $VAULT_ADDR
 vault operator unseal EJoB62t286mjUpSQYZg3mOla3lz/bbElVL5OLnj+rpE=
 ```
 

--- a/docs/how-to/unseal_k8s.md
+++ b/docs/how-to/unseal_k8s.md
@@ -20,7 +20,7 @@ vault/2   blocked   idle   10.1.182.15         Please unseal Vault
 Set the `VAULT_ADDR` variable to the sealed unit:
 
 ```
-export VAULT_ADDR=https://$(juju status vault/2 --format=yaml |  yq '.applications.vault.units.vault/2.address'):8200; echo $VAULT_ADDR
+export VAULT_ADDR=https://$(juju status vault/2 --format=yaml |  yq -r '.applications.vault.units.vault/2.address'):8200; echo $VAULT_ADDR
 ```
 
 Unseal the the unit using the same unseal keys as received during the initialization of the Vault leader:

--- a/docs/tutorial/getting_started_k8s.md
+++ b/docs/tutorial/getting_started_k8s.md
@@ -81,14 +81,14 @@ sudo snap install yq
 Set the `VAULT_ADDR` environment variable:
  
 ```shell
-export VAULT_ADDR=https://$(juju status vault/leader --format=yaml | yq '.applications.vault.address'):8200; echo $VAULT_ADDR
+export VAULT_ADDR=https://$(juju status vault/leader --format=yaml | yq -r '.applications.vault.address'):8200; echo $VAULT_ADDR
 ```
 
 Extract and store Vault's CA certificate to a `vault.pem` file:
 
 ```shell
-cert_juju_secret_id=$(juju secrets --format=yaml | yq 'to_entries | .[] | select(.value.label == "self-signed-vault-ca-certificate") | .key'); echo $cert_juju_secret_id
-juju show-secret ${cert_juju_secret_id} --reveal --format=yaml | yq '.[].content.certificate' > vault.pem
+cert_juju_secret_id=$(juju secrets --format=yaml | yq -r 'to_entries | .[] | select(.value.label == "self-signed-vault-ca-certificate") | .key'); echo $cert_juju_secret_id
+juju show-secret ${cert_juju_secret_id} --reveal --format=yaml | yq -r '.[].content.certificate' > vault.pem
 ```
 
 This will put the CA certificate in a file called `vault.pem`. Now, you can point the `vault` client to this file by setting the `VAULT_CAPATH` variable.

--- a/docs/tutorial/getting_started_machine.md
+++ b/docs/tutorial/getting_started_machine.md
@@ -77,8 +77,8 @@ export VAULT_ADDR=https://$(juju status vault/leader --format=yaml | awk '/publi
 Extract and store Vault's CA certificate to a `vault.pem` file:
 
 ```shell
-cert_juju_secret_id=$(juju secrets --format=yaml | yq 'to_entries | .[] | select(.value.label == "self-signed-vault-ca-certificate") | .key'); echo $cert_juju_secret_id
-juju show-secret ${cert_juju_secret_id} --reveal --format=yaml | yq '.[].content.certificate' > vault.pem
+cert_juju_secret_id=$(juju secrets --format=yaml | yq -r 'to_entries | .[] | select(.value.label == "self-signed-vault-ca-certificate") | .key'); echo $cert_juju_secret_id
+juju show-secret ${cert_juju_secret_id} --reveal --format=yaml | yq -r '.[].content.certificate' > vault.pem
 ```
 
 This will put the CA certificate in a file called `vault.pem`. Now, you can point the `vault` client to this file by setting the `VAULT_CAPATH` variable.

--- a/machine/CONTRIBUTING.md
+++ b/machine/CONTRIBUTING.md
@@ -79,7 +79,7 @@ lxc config set core.storage_buckets_address :8555
 It would, however, be best to lock down the storage buckets to only allow access from other LXD containers.
 
 ```shell
-lxd_bridge_ip=$(lxc network list --format yaml | yq '.[] | select(.name == "lxdbr0") | .config["ipv4.address"]' | cut -d'/' -f1) && echo "LXD bridge IP: ${lxd_bridge_ip}"
+lxd_bridge_ip=$(lxc network list --format yaml | yq -r '.[] | select(.name == "lxdbr0") | .config["ipv4.address"]' | cut -d'/' -f1) && echo "LXD bridge IP: ${lxd_bridge_ip}"
 lxc config set core.storage_buckets_address ${lxd_bridge_ip}:8555
 ```
 


### PR DESCRIPTION
# Description

Duplicates #837 to fix CI.

Otherwise, the output is not compatible with shell commands in the tutorials and documents. e.g.,

$ lxd_bridge_ip=$(lxc network list --format yaml \
    | yq '.[] | select(.name == "lxdbr0") | .config["ipv4.address"]' \
    | cut -d'/' -f1);
$ echo "$lxd_bridge_ip"
"10.0.9.1
^^^ the unexpected double quote in the value

Closes: #836

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
