### PR TITLE
docs: Replace using an existing domain in the docs with a placeholder

### DIFF
--- a/docs/how-to/use_as_acme_server.md
+++ b/docs/how-to/use_as_acme_server.md
@@ -1,6 +1,6 @@
 # Use Vault as an ACME Server to obtain TLS certificates
 
-In this how-to guide, we will configure Vault to act as an ACME server using [Vault's PKI secrets engine](https://developer.hashicorp.com/vault/docs/secrets/pki).  Here [self-signed-certificates](https://charmhub.io/self-signed-certificates) will be the parent CA.
+In this how-to guide, we will configure Vault to act as an ACME server using [Vault's PKI secrets engine](https://developer.hashicorp.com/vault/docs/secrets/pki). Here [self-signed-certificates](https://charmhub.io/self-signed-certificates) will be the parent CA.
 
 The certificates issued by Vault will have a validity period that is half of its intermediate CA's, which is determined by the root provider's configuration, in this case, the self-signed certificates.
 
@@ -10,21 +10,21 @@ Vault ACME will allow issuing certificates depending on how it is configured, pl
 
 1. Configure Vault's common name, and the ACME server to allow issuing certificates for subdomains and any domain name
 
-    ```shell
-    juju config vault acme_ca_common_name=mydomain.com acme_allow_subdomains=true acme_allow_any_name=true
-    ```
+   ```shell
+   juju config vault acme_ca_common_name=<your domain name> acme_allow_subdomains=true acme_allow_any_name=true
+   ```
 
 2. Deploy the parent CA
 
-    ```shell
-    juju deploy self-signed-certificates --channel 1/stable
-    ```
+   ```shell
+   juju deploy self-signed-certificates --channel 1/stable
+   ```
 
 3. Integrate Vault with its parent CA
 
-    ```shell
-    juju integrate vault:tls-certificates-acme self-signed-certificates
-    ```
+   ```shell
+   juju integrate vault:tls-certificates-acme self-signed-certificates
+   ```
 
 Now the ACME server is accessible on `https://<Vault Address>:8200/v1/charm-acme/acme/directory`
 

--- a/docs/how-to/use_as_intermediate_ca.md
+++ b/docs/how-to/use_as_intermediate_ca.md
@@ -12,42 +12,42 @@ Vault PKI will only allow issuing certificates depending on how it is configured
 
 1. Configure Vault's common name
 
-    ```shell
-    juju config vault pki_ca_common_name=mydomain.com
-    ```
+   ```shell
+   juju config vault pki_ca_common_name=<your domain name>
+   ```
 
 2. Configure Vault PKI Engine to allow issuing certificates for subdomains
 
-    ```shell
-    juju config vault pki_allow_subdomains=true
-    ```
+   ```shell
+   juju config vault pki_allow_subdomains=true
+   ```
 
 3. Deploy the parent CA
 
-    ```shell
-    juju deploy self-signed-certificates --channel 1/stable
-    ```
+   ```shell
+   juju deploy self-signed-certificates --channel 1/stable
+   ```
 
 4. Integrate Vault with its parent CA
 
-    ```shell
-    juju integrate vault:tls-certificates-pki self-signed-certificates
-    ```
+   ```shell
+   juju integrate vault:tls-certificates-pki self-signed-certificates
+   ```
 
 5. Deploy `tls-certificates-requirer`
 
-    ```shell
-    juju deploy tls-certificates-requirer --config common_name=demo.mydomain.com  --config sans_dns=demo.mydomain.com
-    ```
+   ```shell
+   juju deploy tls-certificates-requirer --config common_name=<your domain name>  --config sans_dns=<your domain name>
+   ```
 
 6. Integrate TLS Certificates Requirer with Vault
 
-    ```shell
-    juju integrate tls-certificates-requirer vault:vault-pki
-    ```
+   ```shell
+   juju integrate tls-certificates-requirer vault:vault-pki
+   ```
 
 7. Retrieve the certificate
 
-    ```shell
-    juju run tls-certificates-requirer/leader get-certificate
-    ```
+   ```shell
+   juju run tls-certificates-requirer/leader get-certificate
+   ```


### PR DESCRIPTION
# Description

Replace using an existing domain in the docs with a placeholder

Fixes #827 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
