### PR TITLE
docs: Replace using an existing domain in the docs with a placeholder

### DIFF
--- a/docs/how-to/use_as_acme_server.md
+++ b/docs/how-to/use_as_acme_server.md
@@ -1,13 +1,15 @@
 # Use Vault as an ACME Server to obtain TLS certificates
 
-In this how-to guide, we will configure Vault to act as an ACME server using [Vault's PKI secrets engine](https://developer.hashicorp.com/vault/docs/secrets/pki).  Here [self-signed-certificates](https://charmhub.io/self-signed-certificates) will be the parent CA.
+In this how-to guide, we will configure Vault to act as an ACME server using [Vault's PKI secrets engine](https://developer.hashicorp.com/vault/docs/secrets/pki). Here [self-signed-certificates](https://charmhub.io/self-signed-certificates) will be the parent CA.
 
 The certificates issued by Vault will have a validity period that is half of its intermediate CA's, which is determined by the root provider's configuration, in this case, the self-signed certificates.
 
 1. Configure Vault's common name
+
 ```shell
-juju config vault common_name=mydomain.com
+juju config vault common_name=<your domain name>
 ```
+
 2. Deploy the parent CA
 
 ```shell

--- a/docs/how-to/use_as_intermediate_ca.md
+++ b/docs/how-to/use_as_intermediate_ca.md
@@ -11,7 +11,7 @@ The certificates issued by Vault will have a validity period that is half of its
 [note]Vault PKI will only allow issuing certificates for the subdomains of the common_name configured here, it will reject any requests using different domains in their subject.[/note]
 
 ```shell
-juju config vault common_name=mydomain.com
+juju config vault common_name=<your domain name>
 ```
 
 2. Deploy the parent CA
@@ -31,7 +31,7 @@ juju integrate vault:tls-certificates-pki self-signed-certificates
 [note]The common name must be a subdomain of the Vault common name[/note]
 
 ```shell
-juju deploy tls-certificates-requirer --config common_name=demo.mydomain.com  --config sans_dns=demo.mydomain.com
+juju deploy tls-certificates-requirer --config common_name=<your domain name>  --config sans_dns=<your domain name>
 ```
 
 5. Integrate TLS Certificates Requirer with Vault


### PR DESCRIPTION
# Description

Replace using an existing domain in the docs with a placeholder

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
