### PR TITLE
fix: Check if resource config is provided before setting them

### DIFF
--- a/k8s/src/charm.py
+++ b/k8s/src/charm.py
@@ -248,6 +248,12 @@ class VaultCharm(CharmBase):
             self.vault_kv.on.vault_kv_client_detached, self._on_vault_kv_client_detached
         )
 
+    @property
+    def _resource_config_is_set(self) -> bool:
+        """Return whether any resource limit/request config options are set."""
+        resource_config_keys = ("cpu-limit", "memory-limit", "cpu-request", "memory-request")
+        return any(self.juju_facade.get_string_config(key) for key in resource_config_keys)
+
     def _resource_reqs_from_config(self) -> ResourceRequirements:
         limits = {
             k: v
@@ -276,7 +282,7 @@ class VaultCharm(CharmBase):
 
     def _on_collect_status(self, event: CollectStatusEvent):  # noqa: C901
         """Handle the collect status event."""
-        if not self.resources_patch.is_ready():
+        if self._resource_config_is_set and not self.resources_patch.is_ready():
             if isinstance(self.resources_patch.get_status(), WaitingStatus):
                 event.add_status(
                     WaitingStatus(
@@ -442,7 +448,7 @@ class VaultCharm(CharmBase):
         """
         if not self._container.can_connect():
             return
-        if not self.resources_patch.is_ready():
+        if self._resource_config_is_set and not self.resources_patch.is_ready():
             return
         if not self.juju_facade.relation_exists(PEER_RELATION_NAME):
             return

--- a/k8s/tests/unit/test_charm_collect_status.py
+++ b/k8s/tests/unit/test_charm_collect_status.py
@@ -45,6 +45,7 @@ class TestCharmCollectUnitStatus(VaultCharmFixtures):
             relations=[peer_relation],
             secrets=[ca_certificate_secret],
             leader=True,
+            config={"cpu-limit": "1"},
         )
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
@@ -84,10 +85,37 @@ class TestCharmCollectUnitStatus(VaultCharmFixtures):
             relations=[peer_relation],
             secrets=[ca_certificate_secret],
             leader=True,
+            config={"cpu-limit": "1"},
         )
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
         assert state_out.unit_status == BlockedStatus(
+            "Failed to apply resources patch. Please monitor the logs for errors."
+        )
+
+    @patch(
+        "charms.observability_libs.v0.kubernetes_compute_resources_patch.KubernetesComputeResourcesPatch.is_ready",
+        return_value=False,
+    )
+    @patch(
+        "charms.observability_libs.v0.kubernetes_compute_resources_patch.KubernetesComputeResourcesPatch.get_status",
+        return_value=BlockedStatus("Some blocked status message"),
+    )
+    def test_given_resources_patch_not_ready_and_no_resource_config_when_collect_unit_status_then_status_is_not_blocked(
+        self,
+        _: MagicMock,
+        __: MagicMock,
+    ):
+        container = testing.Container(
+            name="vault",
+            can_connect=True,
+        )
+        state_in = testing.State(
+            containers=[container],
+        )
+
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
+        assert state_out.unit_status != BlockedStatus(
             "Failed to apply resources patch. Please monitor the logs for errors."
         )
 


### PR DESCRIPTION
# Description

Fixes #917 
It checks whether kubernetes patch is ready only when they are actually configured in the charm.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
