### PR TITLE
fix: Fix promote workflow missing tag-prefix for monorepo

### DIFF
--- a/.github/workflows/machine-integration-test.yaml
+++ b/.github/workflows/machine-integration-test.yaml
@@ -35,7 +35,7 @@ jobs:
 
   integration-tests:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, X64, large, noble]
     needs: [integration-matrix]
     strategy:
       fail-fast: false

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -49,3 +49,4 @@ jobs:
           destination-channel: ${{ env.TRACK }}/${{ env.PROMOTE_TO }}
           origin-channel: ${{ env.TRACK }}/${{ env.PROMOTE_FROM }}
           charmcraft-channel: latest/stable
+          tag-prefix: ${{ inputs.charm }}


### PR DESCRIPTION
# Description

Promote actions needs a tag-prefix, to differentiate between the machine and the k8s revisions.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
