### PR TITLE
fix: Loosen storage limits

### DIFF
--- a/k8s/charmcraft.yaml
+++ b/k8s/charmcraft.yaml
@@ -45,16 +45,16 @@ resources:
 storage:
   vault-raft:
     type: filesystem
-    minimum-size: 10G
+    minimum-size: 1G
   config:
     type: filesystem
-    minimum-size: 5M
+    minimum-size: 100M
   certs:
     type: filesystem
-    minimum-size: 5M
+    minimum-size: 100M
   tmp:
     type: filesystem
-    minimum-size: 5G
+    minimum-size: 1G
 
 peers:
   vault-peers:


### PR DESCRIPTION
# Description

Loosen storage limits.
Fixes #897 

- XFS requires ≥16MB to format a volume; 5M PVCs fail with mkfs.xfs: size too small
- CSI drivers account for full PVC capacity when calculating available space, so oversized minimums exhaust node storage budgets unnecessarily (These are minimums, not defaults — users can still deploy with --storage vault-raft=50G)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
