### PR TITLE
fix: Add bind address of the unit to the leaf certificates used for internal communication

### DIFF
--- a/k8s/src/charm.py
+++ b/k8s/src/charm.py
@@ -184,6 +184,11 @@ class VaultCharm(CharmBase):
                 access_sans_dns_list = []
             else:
                 access_sans_dns_list.extend([name.strip() for name in access_sans_dns.split(",")])
+        ip_addresses: set[str] = set()
+        if self._bind_address:
+            ip_addresses.add(self._bind_address)
+        if self._ingress_address:
+            ip_addresses.add(self._ingress_address)
         self.tls = TLSManager(
             charm=self,
             workload=self._container,  # type: ignore[arg-type]
@@ -191,7 +196,7 @@ class VaultCharm(CharmBase):
             tls_directory_path=CONTAINER_TLS_FILE_DIRECTORY_PATH,
             common_name=self._ingress_address if self._ingress_address else "",
             sans_dns=frozenset(access_sans_dns_list),
-            sans_ip=frozenset([self._ingress_address] if self._ingress_address else []),
+            sans_ip=frozenset(ip_addresses),
             country_name=self.juju_facade.get_string_config("access_country_name"),
             state_or_province_name=self.juju_facade.get_string_config(
                 "access_state_or_province_name"
@@ -1181,6 +1186,15 @@ class VaultCharm(CharmBase):
         Example: "https://vault-k8s-1.vault-k8s-endpoints.test.svc.cluster.local:8201"
         """
         return f"https://{socket.getfqdn()}:{self.VAULT_CLUSTER_PORT}"
+
+    @property
+    def _bind_address(self) -> str | None:
+        """Fetch the bind address from peer relation and returns it.
+
+        Returns:
+            str: Bind address
+        """
+        return self.juju_facade.get_bind_address(PEER_RELATION_NAME)
 
     @property
     def _ingress_address(self) -> str | None:

--- a/k8s/tests/integration/test_cos.py
+++ b/k8s/tests/integration/test_cos.py
@@ -42,6 +42,12 @@ async def deploy(ops_test: OpsTest, vault_charm_path: Path, skip_deploy: bool) -
         charm_path=vault_charm_path,
         num_units=NUM_VAULT_UNITS,
     )
+    await ops_test.model.wait_for_idle(
+        apps=[APPLICATION_NAME],
+        status="blocked",
+        wait_for_exact_units=NUM_VAULT_UNITS,
+    )
+    root_token, unseal_key = await initialize_unseal_authorize_vault(ops_test, APPLICATION_NAME)
     await ops_test.model.deploy(
         PROMETHEUS_APPLICATION_NAME,
         application_name=PROMETHEUS_APPLICATION_NAME,
@@ -63,11 +69,10 @@ async def deploy(ops_test: OpsTest, vault_charm_path: Path, skip_deploy: bool) -
         ),
         ops_test.model.wait_for_idle(
             apps=[APPLICATION_NAME],
-            status="blocked",
+            status="active",
             wait_for_exact_units=NUM_VAULT_UNITS,
         ),
     )
-    root_token, unseal_key = await initialize_unseal_authorize_vault(ops_test, APPLICATION_NAME)
     return VaultInit(root_token, unseal_key)
 
 

--- a/k8s/tests/integration/test_pki.py
+++ b/k8s/tests/integration/test_pki.py
@@ -54,6 +54,18 @@ async def deploy(
         channel="1/stable",
         num_units=1,
     )
+    await asyncio.gather(
+        ops_test.model.wait_for_idle(
+            apps=[APPLICATION_NAME],
+            status="blocked",
+            wait_for_exact_units=NUM_VAULT_UNITS,
+        ),
+        ops_test.model.wait_for_idle(
+            apps=[SELF_SIGNED_CERTIFICATES_APPLICATION_NAME],
+            status="active",
+        ),
+    )
+    root_token, unseal_key = await initialize_unseal_authorize_vault(ops_test, APPLICATION_NAME)
     await ops_test.model.deploy(
         pki_requirer_charm_path
         if pki_requirer_charm_path
@@ -63,18 +75,10 @@ async def deploy(
         channel="stable",
         config={"common_name": "test.example.com", "sans_dns": "test.example.com"},
     )
-    await asyncio.gather(
-        ops_test.model.wait_for_idle(
-            apps=[APPLICATION_NAME],
-            status="blocked",
-            wait_for_exact_units=NUM_VAULT_UNITS,
-        ),
-        ops_test.model.wait_for_idle(
-            apps=[VAULT_PKI_REQUIRER_APPLICATION_NAME, SELF_SIGNED_CERTIFICATES_APPLICATION_NAME],
-            status="active",
-        ),
+    await ops_test.model.wait_for_idle(
+        apps=[VAULT_PKI_REQUIRER_APPLICATION_NAME],
+        status="active",
     )
-    root_token, unseal_key = await initialize_unseal_authorize_vault(ops_test, APPLICATION_NAME)
     return VaultInit(root_token, unseal_key)
 
 

--- a/k8s/tests/integration/vault_helpers.py
+++ b/k8s/tests/integration/vault_helpers.py
@@ -88,10 +88,19 @@ class Vault:
             ca_file_location (str): The path to the CA file
             unseal_key (str): The unseal key
         """
-        if not self.client.sys.is_sealed():
-            return
-        self.client.sys.submit_unseal_key(unseal_key)
-        logger.info("Unsealed vault unit: %s.", self.url)
+        timeout = 300
+        t0 = time.time()
+        while time.time() < t0 + timeout:
+            try:
+                if not self.client.sys.is_sealed():
+                    return
+                self.client.sys.submit_unseal_key(unseal_key)
+                logger.info("Unsealed vault unit: %s.", self.url)
+                return
+            except requests.exceptions.RequestException:
+                logger.debug("Vault is not yet available. Waiting...")
+                time.sleep(5)
+        raise TimeoutError("Timed out unsealing vault unit.")
 
     async def wait_for_raft_nodes(self, expected_num_nodes: int) -> None:
         """Wait for the specified number of units to join the raft cluster.

--- a/k8s/tests/unit/lib/test_vault_tls.py
+++ b/k8s/tests/unit/lib/test_vault_tls.py
@@ -218,7 +218,7 @@ class TestCharmTLS:
                 certificate_request=CertificateRequestAttributes(
                     common_name=ingress_address,
                     sans_dns=frozenset({self.fqdn}),
-                    sans_ip=frozenset({ingress_address}),
+                    sans_ip=frozenset({ingress_address, "192.0.2.1"}),
                     sans_oid=frozenset(),
                     email_address=None,
                     organization=None,
@@ -303,7 +303,7 @@ class TestCharmTLS:
                 certificate_request=CertificateRequestAttributes(
                     common_name=ingress_address,
                     sans_dns=frozenset({self.fqdn, "mydomain.com", "mydomain.org"}),
-                    sans_ip=frozenset({ingress_address}),
+                    sans_ip=frozenset({ingress_address, "192.0.2.1"}),
                     sans_oid=frozenset(),
                     email_address="my@email.com",
                     organization="My Organization",
@@ -524,7 +524,7 @@ class TestCharmTLS:
                 private_key=private_key,
                 common_name=ingress_address,
                 sans_dns=frozenset([self.fqdn]),
-                sans_ip=frozenset([ingress_address]),
+                sans_ip=frozenset([ingress_address, "192.0.2.1"]),
             )
             certificate = generate_certificate(
                 csr=csr,

--- a/machine/.vendored/vault-package/vault/security_logger.py
+++ b/machine/.vendored/vault-package/vault/security_logger.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # Licensed under the Apache2.0. See LICENSE file in charm source for details.
 
 """Shared OWASP-style security logger utilities.


### PR DESCRIPTION
# Description

Backports #1016
Add bind address of the unit to the leaf certificates used for internal communication

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of any required library.
