### PR TITLE
fix(ci): pin grafana-dashboard-lint-report workflow to v3.1.2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,7 +37,7 @@ jobs:
       path: ./k8s/
 
   k8s-grafana-dashboard-lint-report:
-    uses: canonical/identity-credentials-workflows/.github/workflows/grafana-dashboard-lint-report.yaml@v1
+    uses: canonical/identity-credentials-workflows/.github/workflows/grafana-dashboard-lint-report.yaml@v3.1.2
     with:
       path: ./k8s/src/grafana_dashboards/*
 
@@ -162,7 +162,7 @@ jobs:
       path: ./machine/
 
   machine-grafana-dashboard-lint-report:
-    uses: canonical/identity-credentials-workflows/.github/workflows/grafana-dashboard-lint-report.yaml@v1
+    uses: canonical/identity-credentials-workflows/.github/workflows/grafana-dashboard-lint-report.yaml@v3.1.2
     with:
       path: ./machine/src/grafana_dashboards/*
 


### PR DESCRIPTION
## Description

The `v1` tag of `canonical/identity-credentials-workflows/.github/workflows/grafana-dashboard-lint-report.yaml` sets up Go 1.25 and runs `go install github.com/grafana/dashboard-linter@latest`. The linter's latest release (v0.2.0) now requires Go >= 1.26.3, so the job fails:

```
go: github.com/grafana/dashboard-linter@latest: github.com/grafana/dashboard-linter@v0.2.0 requires go >= 1.26.3 (running go 1.25.11; GOTOOLCHAIN=local)
```

Because `k8s-publish-charm` and `machine-publish-charm` (and their ARM variants) list the grafana lint jobs in `needs:`, this failure also skips all publish jobs on this release branch.

This bumps only the grafana lint workflow ref to `v3.1.2` (same version `main` uses), which sets up Go 1.26 and builds a pinned dashboard-linter v0.1.1 from source. The workflow interface (`path` input) is unchanged, so this is a drop-in fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)