### PR TITLE
fix: use s3 tls-ca-chain and path prefix in backup actions

### DIFF
--- a/.github/workflows/build-kv-requirer.yaml
+++ b/.github/workflows/build-kv-requirer.yaml
@@ -24,7 +24,7 @@ jobs:
           channel: 5.21/stable
 
       - name: Install charmcraft
-        run: sudo snap install charmcraft --classic
+        run: sudo snap install charmcraft --classic --revision=8022
 
       - name: Build KV Requirer charm
         working-directory: ${{ inputs.path }}

--- a/.github/workflows/machine-integration-test.yaml
+++ b/.github/workflows/machine-integration-test.yaml
@@ -76,7 +76,7 @@ jobs:
           echo "vault-charm=${VAULT_CHARM}" >> "$GITHUB_OUTPUT"
           echo "kv-charm=${KV_CHARM}" >> "$GITHUB_OUTPUT"
       - name: Install minio binaries and configure storage buckets for backup tests
-        if: ${{ matrix.suite == 'test_backup.py' }}
+        if: ${{ matrix.suite == 'test_backup.py' || matrix.suite == 'test_backup_tls.py' }}
         run: |
           minio_binaries_path="/var/snap/lxd/common/minio"
           sudo mkdir -p ${minio_binaries_path}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 .tox
 .venv/
 *.egg-info/
+uv.lock
 
 .coverage
 __pycache__/

--- a/docs/how-to/restore_backup.md
+++ b/docs/how-to/restore_backup.md
@@ -25,6 +25,21 @@ You can get a list of the identifiers of all the backups that are stored on the 
 
 `juju run vault/leader list-backups`
 
+If you are using the [S3-integrator](https://charmhub.io/s3-integrator) charm, when a `path` is configured,
+`list-backups` only returns backups stored under that path. Backups created *before* a `path` was set are stored
+at the bucket root and will no longer appear in the output, even though they are still present in the bucket.
+You can get a list of these root-level backups by setting the `path` to empty and running `list-backups`:
+
+```
+S3_PATH=$(juju config s3-integrator path)
+juju config s3-integrator path=""
+juju run vault/leader list-backups
+juju config s3-integrator path="$S3_PATH"
+```
+
+To restore a legacy root-level backups, pass its key to the `restore-backup` action; even though a `path`
+may be configured, any existing root-level backups are still accessible by their key.
+
 ## Restore Backups created in different environments
 
 To restore a snapshot that wasn't created using the Vault charm's `create-backup` action, you'll need to manually upload it to the S3 storage accessible by the Vault charm where the `restore-backup` action will run.

--- a/k8s/.vendored/vault-package/vault/vault_managers.py
+++ b/k8s/.vendored/vault-package/vault/vault_managers.py
@@ -28,14 +28,16 @@ Feature managers should not:
 - Depend on each other unless the features explicitly require the dependency.
 """
 
+import contextlib
 import json
 import logging
 import os
+import tempfile
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from enum import Enum, auto
 from functools import cached_property
-from typing import FrozenSet, List, MutableMapping, Optional, Sequence, TextIO
+from typing import FrozenSet, Iterator, List, Mapping, MutableMapping, TextIO
 
 from charms.certificate_transfer_interface.v1.certificate_transfer import (
     CertificateTransferProvides,
@@ -1537,40 +1539,43 @@ class BackupManager:
         self._validate_s3_prerequisites()
 
         s3_parameters = self._get_s3_parameters()
+        path_prefix = self._normalize_path(s3_parameters)
+        with self._ca_cert_bundle(s3_parameters) as ca_cert_path:
+            try:
+                s3 = S3(
+                    access_key=s3_parameters["access-key"],
+                    secret_key=s3_parameters["secret-key"],
+                    endpoint=s3_parameters["endpoint"],
+                    region=s3_parameters.get("region"),
+                    skip_verify=skip_verify,
+                    application=self._charm.app.name,
+                    ca_cert_path=ca_cert_path,
+                )
+            except S3Error as e:
+                logger.error("Failed to create S3 session. %s", e)
+                raise ManagerError("Failed to create S3 session")
 
-        try:
-            s3 = S3(
-                access_key=s3_parameters["access-key"],
-                secret_key=s3_parameters["secret-key"],
-                endpoint=s3_parameters["endpoint"],
-                region=s3_parameters.get("region"),
-                skip_verify=skip_verify,
-                application=self._charm.app.name,
+            if not (s3.create_bucket(bucket_name=s3_parameters["bucket"])):
+                raise ManagerError("Failed to create S3 bucket")
+            backup_key = f"{path_prefix}{Naming.backup_s3_key_name(self._charm.model.name)}"
+
+            response = vault_client.create_snapshot()
+            content_uploaded = s3.upload_content(
+                content=response.raw,  # type: ignore[reportArgumentType]
+                bucket_name=s3_parameters["bucket"],
+                key=backup_key,
             )
-        except S3Error as e:
-            logger.error("Failed to create S3 session. %s", e)
-            raise ManagerError("Failed to create S3 session")
-
-        if not (s3.create_bucket(bucket_name=s3_parameters["bucket"])):
-            raise ManagerError("Failed to create S3 bucket")
-        backup_key = Naming.backup_s3_key_name(self._charm.model.name)
-
-        response = vault_client.create_snapshot()
-        content_uploaded = s3.upload_content(
-            content=response.raw,  # type: ignore[reportArgumentType]
-            bucket_name=s3_parameters["bucket"],
-            key=backup_key,
-        )
-        if not content_uploaded:
-            raise ManagerError("Failed to upload backup to S3 bucket")
-        logger.info("Backup uploaded to S3 bucket %s", s3_parameters["bucket"])
-        return backup_key
+            if not content_uploaded:
+                raise ManagerError("Failed to upload backup to S3 bucket")
+            logger.info("Backup uploaded to S3 bucket %s", s3_parameters["bucket"])
+            return backup_key
 
     def list_backups(self, skip_verify: bool = False) -> list[str]:
         """List all the backups available in the S3 bucket.
 
         Backups are identified by the key prefix from
-        ``Naming.backup_s3_key_prefix``.
+        ``Naming.backup_s3_key_prefix``, prepended with the S3 relation
+        ``path`` when one is configured.
 
         Args:
             skip_verify: Whether to skip verification of the S3 connection.
@@ -1581,26 +1586,29 @@ class BackupManager:
         self._validate_s3_prerequisites()
 
         s3_parameters = self._get_s3_parameters()
+        path_prefix = self._normalize_path(s3_parameters)
+        with self._ca_cert_bundle(s3_parameters) as ca_cert_path:
+            try:
+                s3 = S3(
+                    access_key=s3_parameters["access-key"],
+                    secret_key=s3_parameters["secret-key"],
+                    endpoint=s3_parameters["endpoint"],
+                    region=s3_parameters.get("region"),
+                    skip_verify=skip_verify,
+                    application=self._charm.app.name,
+                    ca_cert_path=ca_cert_path,
+                )
+            except S3Error:
+                raise ManagerError("Failed to create S3 session")
 
-        try:
-            s3 = S3(
-                access_key=s3_parameters["access-key"],
-                secret_key=s3_parameters["secret-key"],
-                endpoint=s3_parameters["endpoint"],
-                region=s3_parameters.get("region"),
-                skip_verify=skip_verify,
-                application=self._charm.app.name,
-            )
-        except S3Error:
-            raise ManagerError("Failed to create S3 session")
-
-        try:
-            backup_ids = s3.get_object_key_list(
-                bucket_name=s3_parameters["bucket"], prefix=Naming.backup_s3_key_prefix
-            )
-        except S3Error as e:
-            raise ManagerError(f"Failed to list backups in S3 bucket: {e}")
-        return backup_ids
+            try:
+                backup_ids = s3.get_object_key_list(
+                    bucket_name=s3_parameters["bucket"],
+                    prefix=f"{path_prefix}{Naming.backup_s3_key_prefix}",
+                )
+            except S3Error as e:
+                raise ManagerError(f"Failed to list backups in S3 bucket: {e}")
+            return backup_ids
 
     def restore_backup(
         self, vault_client: VaultClient, backup_key: str, skip_verify: bool = False
@@ -1615,35 +1623,50 @@ class BackupManager:
         self._validate_s3_prerequisites()
 
         s3_parameters = self._get_s3_parameters()
+        path_prefix = self._normalize_path(s3_parameters)
+        with self._ca_cert_bundle(s3_parameters) as ca_cert_path:
+            try:
+                s3 = S3(
+                    access_key=s3_parameters["access-key"],
+                    secret_key=s3_parameters["secret-key"],
+                    endpoint=s3_parameters["endpoint"],
+                    region=s3_parameters.get("region"),
+                    skip_verify=skip_verify,
+                    application=self._charm.app.name,
+                    ca_cert_path=ca_cert_path,
+                )
+            except S3Error:
+                raise ManagerError("Failed to create S3 session")
 
-        try:
-            s3 = S3(
-                access_key=s3_parameters["access-key"],
-                secret_key=s3_parameters["secret-key"],
-                endpoint=s3_parameters["endpoint"],
-                region=s3_parameters.get("region"),
-                skip_verify=skip_verify,
-                application=self._charm.app.name,
-            )
-        except S3Error:
-            raise ManagerError("Failed to create S3 session")
+            # If the supplied key is already prefixed, fetch it directly.
+            # Otherwise try the path-prefixed key first and fall back to the raw key.
+            if path_prefix and backup_key.startswith(path_prefix):
+                candidates = [backup_key]
+            else:
+                prefixed_key = f"{path_prefix}{backup_key}"
+                candidates = (
+                    [prefixed_key] if prefixed_key == backup_key else [prefixed_key, backup_key]
+                )
+            try:
+                snapshot = None
+                for candidate in candidates:
+                    snapshot = s3.get_content(
+                        bucket_name=s3_parameters["bucket"],
+                        object_key=candidate,
+                    )
+                    if snapshot:
+                        break
+            except S3Error as e:
+                raise ManagerError(f"Failed to retrieve snapshot from S3: {e}")
+            if not snapshot:
+                raise ManagerError(
+                    f"Snapshot not found in S3 bucket. ({s3_parameters['bucket']}/{backup_key})"
+                )
 
-        try:
-            snapshot = s3.get_content(
-                bucket_name=s3_parameters["bucket"],
-                object_key=backup_key,
-            )
-        except S3Error as e:
-            raise ManagerError(f"Failed to retrieve snapshot from S3: {e}")
-        if not snapshot:
-            raise ManagerError(
-                f"Snapshot not found in S3 bucket. ({s3_parameters['bucket']}/{backup_key})"
-            )
-
-        try:
-            vault_client.restore_snapshot(snapshot=snapshot)
-        except VaultClientError as e:
-            raise ManagerError(f"Failed to restore snapshot: {e}")
+            try:
+                vault_client.restore_snapshot(snapshot=snapshot)
+            except VaultClientError as e:
+                raise ManagerError(f"Failed to restore snapshot: {e}")
 
     def _validate_s3_prerequisites(self) -> str | None:
         """Validate the S3 pre-requisites are met.
@@ -1680,6 +1703,53 @@ class BackupManager:
             if isinstance(value, str):
                 s3_parameters[key] = value.strip()
         return s3_parameters
+
+    def _normalize_path(self, s3_parameters: Mapping[str, object]) -> str:
+        """Return the S3 relation ``path`` as a normalized key prefix.
+
+        Strips leading and trailing slashes from the ``path`` field and
+        appends a trailing slash so it can be prepended to object keys.
+        Returns an empty string when no path is configured, so it is a no-op
+        when ``path`` is absent.
+
+        Args:
+            s3_parameters: S3 relation parameters.
+
+        Returns:
+            A prefix such as ``"vault/"`` or an empty string.
+        """
+        path = s3_parameters.get("path")
+        if not path or not isinstance(path, str):
+            return ""
+        stripped = path.strip("/")
+        if not stripped:
+            return ""
+        return f"{stripped}/"
+
+    @contextlib.contextmanager
+    def _ca_cert_bundle(self, s3_parameters: Mapping[str, object]) -> Iterator[str | None]:
+        """Extract the S3 relation ``tls-ca-chain`` to a temporary PEM file.
+
+        The s3-integrator relation provides ``tls-ca-chain`` as a JSON list of
+        PEM strings. boto3's ``verify`` parameter accepts a path to a CA bundle
+        file, so the chain is written to a temporary file and its path yielded.
+        The file is removed once the enclosing ``with`` block exits.
+
+        Yields:
+            The path to the temporary CA bundle file, or ``None`` when the
+            relation does not provide a ``tls-ca-chain`` or it is malformed.
+        """
+        tls_ca_chain = s3_parameters.get("tls-ca-chain")
+        if not tls_ca_chain or not isinstance(tls_ca_chain, list):
+            yield None
+            return
+        fd, path = tempfile.mkstemp(suffix=".pem")
+        try:
+            with os.fdopen(fd, "w") as ca_file:
+                ca_file.write("\n".join(tls_ca_chain))
+            yield path
+        finally:
+            os.unlink(path)
 
 
 class RaftManager:

--- a/k8s/.vendored/vault-package/vault/vault_s3.py
+++ b/k8s/.vendored/vault-package/vault/vault_s3.py
@@ -71,6 +71,7 @@ class S3:
         application: str = "vault",
         region: str | None = AWS_DEFAULT_REGION,
         skip_verify: bool = False,
+        ca_cert_path: str | None = None,
     ):
         self.access_key = access_key
         self.secret_key = secret_key
@@ -78,11 +79,12 @@ class S3:
         self.region = region
         self._security_logger = _OWASPLogger(application=application)
 
-        if skip_verify is False:
+        if skip_verify is True:
             logger.warning(
                 "S3 client is configured to skip SSL certificate verification. "
                 "This is insecure and should only be used in development environments."
             )
+        verify = False if skip_verify else (ca_cert_path or None)
         try:
             self.session = boto3.session.Session(
                 aws_access_key_id=self.access_key,
@@ -101,7 +103,7 @@ class S3:
                 "s3",
                 endpoint_url=self.endpoint,
                 config=custom_config,
-                verify=False if skip_verify else None,
+                verify=verify,
             )
         except (ClientError, BotoCoreError, ValueError) as e:
             raise S3Error(f"Error creating session: {e}")

--- a/k8s/tests/unit/lib/test_vault_managers.py
+++ b/k8s/tests/unit/lib/test_vault_managers.py
@@ -1049,6 +1049,147 @@ class TestBackupManager:
         self.manager.restore_backup(self.vault_client, "vault-backup-my-model-1")
         self.vault_client.restore_snapshot.assert_called_once_with(snapshot="snapshot content")
 
+    def test_given_path_when_create_backup_then_key_is_prefixed(self):
+        self.s3_requirer.get_s3_connection_info.return_value = {
+            "bucket": "my-bucket",
+            "access-key": "my-access-key",
+            "secret-key": "my-secret-key",
+            "endpoint": "my-endpoint",
+            "region": "my-region",
+            "path": "vault",
+        }
+        key = self.manager.create_backup(self.vault_client)
+
+        assert key.startswith("vault/vault-backup-my-model-")
+        self.s3.upload_content.assert_called_once()
+        assert self.s3.upload_content.call_args.kwargs["key"] == key
+
+    def test_path_with_surrounding_slashes_is_normalized_when_create_backup(self):
+        self.s3_requirer.get_s3_connection_info.return_value = {
+            "bucket": "my-bucket",
+            "access-key": "my-access-key",
+            "secret-key": "my-secret-key",
+            "endpoint": "my-endpoint",
+            "region": "my-region",
+            "path": "/vault/",
+        }
+        key = self.manager.create_backup(self.vault_client)
+
+        assert key.startswith("vault/vault-backup-my-model-")
+
+    def test_given_no_path_when_create_backup_then_key_is_not_prefixed(self):
+        key = self.manager.create_backup(self.vault_client)
+
+        assert key.startswith("vault-backup-my-model-")
+        assert not key.startswith("/")
+
+    def test_given_path_when_list_backups_then_prefix_is_prefixed(self):
+        self.s3_requirer.get_s3_connection_info.return_value = {
+            "bucket": "my-bucket",
+            "access-key": "my-access-key",
+            "secret-key": "my-secret-key",
+            "endpoint": "my-endpoint",
+            "region": "my-region",
+            "path": "vault",
+        }
+        self.manager.list_backups()
+
+        self.s3.get_object_key_list.assert_called_once()
+        assert self.s3.get_object_key_list.call_args.kwargs["prefix"] == "vault/vault-backup-"
+
+    def test_given_no_path_when_list_backups_then_prefix_is_unprefixed(self):
+        self.manager.list_backups()
+
+        assert self.s3.get_object_key_list.call_args.kwargs["prefix"] == "vault-backup-"
+
+    def test_given_path_when_restore_backup_then_prefixed_key_tried_first(self):
+        self.s3_requirer.get_s3_connection_info.return_value = {
+            "bucket": "my-bucket",
+            "access-key": "my-access-key",
+            "secret-key": "my-secret-key",
+            "endpoint": "my-endpoint",
+            "region": "my-region",
+            "path": "vault",
+        }
+        self.s3.get_content.return_value = "snapshot content"
+
+        self.manager.restore_backup(self.vault_client, "vault-backup-my-model-1")
+
+        self.s3.get_content.assert_called_once()
+        assert self.s3.get_content.call_args.kwargs["object_key"] == (
+            "vault/vault-backup-my-model-1"
+        )
+
+    def test_given_prefixed_key_missing_when_restore_backup_then_falls_back_to_raw_key(self):
+        self.s3_requirer.get_s3_connection_info.return_value = {
+            "bucket": "my-bucket",
+            "access-key": "my-access-key",
+            "secret-key": "my-secret-key",
+            "endpoint": "my-endpoint",
+            "region": "my-region",
+            "path": "vault",
+        }
+        # First get_content (prefixed key) returns None, second (raw key) returns content.
+        self.s3.get_content.side_effect = [None, "snapshot content"]
+
+        self.manager.restore_backup(self.vault_client, "vault-backup-my-model-1")
+
+        assert self.s3.get_content.call_count == 2
+        assert self.s3.get_content.call_args_list[0].kwargs["object_key"] == (
+            "vault/vault-backup-my-model-1"
+        )
+        assert self.s3.get_content.call_args_list[1].kwargs["object_key"] == (
+            "vault-backup-my-model-1"
+        )
+        self.vault_client.restore_snapshot.assert_called_once_with(snapshot="snapshot content")
+
+    def test_given_no_path_when_restore_backup_then_raw_key_used(self):
+        self.s3.get_content.return_value = "snapshot content"
+
+        self.manager.restore_backup(self.vault_client, "vault-backup-my-model-1")
+
+        self.s3.get_content.assert_called_once()
+        assert self.s3.get_content.call_args.kwargs["object_key"] == "vault-backup-my-model-1"
+
+    def test_given_already_prefixed_key_when_restore_backup_then_key_not_prefixed_again(self):
+        self.s3_requirer.get_s3_connection_info.return_value = {
+            "bucket": "my-bucket",
+            "access-key": "my-access-key",
+            "secret-key": "my-secret-key",
+            "endpoint": "my-endpoint",
+            "region": "my-region",
+            "path": "vault",
+        }
+        self.s3.get_content.return_value = "snapshot content"
+        already_prefixed_key = "vault/vault-backup-my-model-1"
+
+        self.manager.restore_backup(self.vault_client, already_prefixed_key)
+
+        # Only one fetch is performed and the key is not double-prefixed.
+        self.s3.get_content.assert_called_once()
+        assert self.s3.get_content.call_args.kwargs["object_key"] == already_prefixed_key
+        self.vault_client.restore_snapshot.assert_called_once_with(snapshot="snapshot content")
+
+    def test_given_tls_ca_chain_when_create_backup_then_ca_cert_path_passed_to_s3(self):
+        self.s3_requirer.get_s3_connection_info.return_value = {
+            "bucket": "my-bucket",
+            "access-key": "my-access-key",
+            "secret-key": "my-secret-key",
+            "endpoint": "my-endpoint",
+            "region": "my-region",
+            "tls-ca-chain": ["-----BEGIN CERTIFICATE-----\nfoo\n-----END CERTIFICATE-----"],
+        }
+
+        self.manager.create_backup(self.vault_client)
+
+        assert self.s3_class.call_args.kwargs["ca_cert_path"] is not None
+        assert self.s3_class.call_args.kwargs["ca_cert_path"].endswith(".pem")
+
+    def test_given_no_tls_ca_chain_when_create_backup_then_ca_cert_path_is_none(self):
+        self.manager.create_backup(self.vault_client)
+
+        assert self.s3_class.call_args.kwargs["ca_cert_path"] is None
+
 
 class TestRaftManager:
     @pytest.fixture(autouse=True)

--- a/machine/.vendored/vault-package/vault/vault_managers.py
+++ b/machine/.vendored/vault-package/vault/vault_managers.py
@@ -28,14 +28,16 @@ Feature managers should not:
 - Depend on each other unless the features explicitly require the dependency.
 """
 
+import contextlib
 import json
 import logging
 import os
+import tempfile
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from enum import Enum, auto
 from functools import cached_property
-from typing import FrozenSet, List, MutableMapping, Optional, Sequence, TextIO
+from typing import FrozenSet, Iterator, List, Mapping, MutableMapping, TextIO
 
 from charms.certificate_transfer_interface.v1.certificate_transfer import (
     CertificateTransferProvides,
@@ -1537,40 +1539,43 @@ class BackupManager:
         self._validate_s3_prerequisites()
 
         s3_parameters = self._get_s3_parameters()
+        path_prefix = self._normalize_path(s3_parameters)
+        with self._ca_cert_bundle(s3_parameters) as ca_cert_path:
+            try:
+                s3 = S3(
+                    access_key=s3_parameters["access-key"],
+                    secret_key=s3_parameters["secret-key"],
+                    endpoint=s3_parameters["endpoint"],
+                    region=s3_parameters.get("region"),
+                    skip_verify=skip_verify,
+                    application=self._charm.app.name,
+                    ca_cert_path=ca_cert_path,
+                )
+            except S3Error as e:
+                logger.error("Failed to create S3 session. %s", e)
+                raise ManagerError("Failed to create S3 session")
 
-        try:
-            s3 = S3(
-                access_key=s3_parameters["access-key"],
-                secret_key=s3_parameters["secret-key"],
-                endpoint=s3_parameters["endpoint"],
-                region=s3_parameters.get("region"),
-                skip_verify=skip_verify,
-                application=self._charm.app.name,
+            if not (s3.create_bucket(bucket_name=s3_parameters["bucket"])):
+                raise ManagerError("Failed to create S3 bucket")
+            backup_key = f"{path_prefix}{Naming.backup_s3_key_name(self._charm.model.name)}"
+
+            response = vault_client.create_snapshot()
+            content_uploaded = s3.upload_content(
+                content=response.raw,  # type: ignore[reportArgumentType]
+                bucket_name=s3_parameters["bucket"],
+                key=backup_key,
             )
-        except S3Error as e:
-            logger.error("Failed to create S3 session. %s", e)
-            raise ManagerError("Failed to create S3 session")
-
-        if not (s3.create_bucket(bucket_name=s3_parameters["bucket"])):
-            raise ManagerError("Failed to create S3 bucket")
-        backup_key = Naming.backup_s3_key_name(self._charm.model.name)
-
-        response = vault_client.create_snapshot()
-        content_uploaded = s3.upload_content(
-            content=response.raw,  # type: ignore[reportArgumentType]
-            bucket_name=s3_parameters["bucket"],
-            key=backup_key,
-        )
-        if not content_uploaded:
-            raise ManagerError("Failed to upload backup to S3 bucket")
-        logger.info("Backup uploaded to S3 bucket %s", s3_parameters["bucket"])
-        return backup_key
+            if not content_uploaded:
+                raise ManagerError("Failed to upload backup to S3 bucket")
+            logger.info("Backup uploaded to S3 bucket %s", s3_parameters["bucket"])
+            return backup_key
 
     def list_backups(self, skip_verify: bool = False) -> list[str]:
         """List all the backups available in the S3 bucket.
 
         Backups are identified by the key prefix from
-        ``Naming.backup_s3_key_prefix``.
+        ``Naming.backup_s3_key_prefix``, prepended with the S3 relation
+        ``path`` when one is configured.
 
         Args:
             skip_verify: Whether to skip verification of the S3 connection.
@@ -1581,26 +1586,29 @@ class BackupManager:
         self._validate_s3_prerequisites()
 
         s3_parameters = self._get_s3_parameters()
+        path_prefix = self._normalize_path(s3_parameters)
+        with self._ca_cert_bundle(s3_parameters) as ca_cert_path:
+            try:
+                s3 = S3(
+                    access_key=s3_parameters["access-key"],
+                    secret_key=s3_parameters["secret-key"],
+                    endpoint=s3_parameters["endpoint"],
+                    region=s3_parameters.get("region"),
+                    skip_verify=skip_verify,
+                    application=self._charm.app.name,
+                    ca_cert_path=ca_cert_path,
+                )
+            except S3Error:
+                raise ManagerError("Failed to create S3 session")
 
-        try:
-            s3 = S3(
-                access_key=s3_parameters["access-key"],
-                secret_key=s3_parameters["secret-key"],
-                endpoint=s3_parameters["endpoint"],
-                region=s3_parameters.get("region"),
-                skip_verify=skip_verify,
-                application=self._charm.app.name,
-            )
-        except S3Error:
-            raise ManagerError("Failed to create S3 session")
-
-        try:
-            backup_ids = s3.get_object_key_list(
-                bucket_name=s3_parameters["bucket"], prefix=Naming.backup_s3_key_prefix
-            )
-        except S3Error as e:
-            raise ManagerError(f"Failed to list backups in S3 bucket: {e}")
-        return backup_ids
+            try:
+                backup_ids = s3.get_object_key_list(
+                    bucket_name=s3_parameters["bucket"],
+                    prefix=f"{path_prefix}{Naming.backup_s3_key_prefix}",
+                )
+            except S3Error as e:
+                raise ManagerError(f"Failed to list backups in S3 bucket: {e}")
+            return backup_ids
 
     def restore_backup(
         self, vault_client: VaultClient, backup_key: str, skip_verify: bool = False
@@ -1615,35 +1623,50 @@ class BackupManager:
         self._validate_s3_prerequisites()
 
         s3_parameters = self._get_s3_parameters()
+        path_prefix = self._normalize_path(s3_parameters)
+        with self._ca_cert_bundle(s3_parameters) as ca_cert_path:
+            try:
+                s3 = S3(
+                    access_key=s3_parameters["access-key"],
+                    secret_key=s3_parameters["secret-key"],
+                    endpoint=s3_parameters["endpoint"],
+                    region=s3_parameters.get("region"),
+                    skip_verify=skip_verify,
+                    application=self._charm.app.name,
+                    ca_cert_path=ca_cert_path,
+                )
+            except S3Error:
+                raise ManagerError("Failed to create S3 session")
 
-        try:
-            s3 = S3(
-                access_key=s3_parameters["access-key"],
-                secret_key=s3_parameters["secret-key"],
-                endpoint=s3_parameters["endpoint"],
-                region=s3_parameters.get("region"),
-                skip_verify=skip_verify,
-                application=self._charm.app.name,
-            )
-        except S3Error:
-            raise ManagerError("Failed to create S3 session")
+            # If the supplied key is already prefixed, fetch it directly.
+            # Otherwise try the path-prefixed key first and fall back to the raw key.
+            if path_prefix and backup_key.startswith(path_prefix):
+                candidates = [backup_key]
+            else:
+                prefixed_key = f"{path_prefix}{backup_key}"
+                candidates = (
+                    [prefixed_key] if prefixed_key == backup_key else [prefixed_key, backup_key]
+                )
+            try:
+                snapshot = None
+                for candidate in candidates:
+                    snapshot = s3.get_content(
+                        bucket_name=s3_parameters["bucket"],
+                        object_key=candidate,
+                    )
+                    if snapshot:
+                        break
+            except S3Error as e:
+                raise ManagerError(f"Failed to retrieve snapshot from S3: {e}")
+            if not snapshot:
+                raise ManagerError(
+                    f"Snapshot not found in S3 bucket. ({s3_parameters['bucket']}/{backup_key})"
+                )
 
-        try:
-            snapshot = s3.get_content(
-                bucket_name=s3_parameters["bucket"],
-                object_key=backup_key,
-            )
-        except S3Error as e:
-            raise ManagerError(f"Failed to retrieve snapshot from S3: {e}")
-        if not snapshot:
-            raise ManagerError(
-                f"Snapshot not found in S3 bucket. ({s3_parameters['bucket']}/{backup_key})"
-            )
-
-        try:
-            vault_client.restore_snapshot(snapshot=snapshot)
-        except VaultClientError as e:
-            raise ManagerError(f"Failed to restore snapshot: {e}")
+            try:
+                vault_client.restore_snapshot(snapshot=snapshot)
+            except VaultClientError as e:
+                raise ManagerError(f"Failed to restore snapshot: {e}")
 
     def _validate_s3_prerequisites(self) -> str | None:
         """Validate the S3 pre-requisites are met.
@@ -1680,6 +1703,53 @@ class BackupManager:
             if isinstance(value, str):
                 s3_parameters[key] = value.strip()
         return s3_parameters
+
+    def _normalize_path(self, s3_parameters: Mapping[str, object]) -> str:
+        """Return the S3 relation ``path`` as a normalized key prefix.
+
+        Strips leading and trailing slashes from the ``path`` field and
+        appends a trailing slash so it can be prepended to object keys.
+        Returns an empty string when no path is configured, so it is a no-op
+        when ``path`` is absent.
+
+        Args:
+            s3_parameters: S3 relation parameters.
+
+        Returns:
+            A prefix such as ``"vault/"`` or an empty string.
+        """
+        path = s3_parameters.get("path")
+        if not path or not isinstance(path, str):
+            return ""
+        stripped = path.strip("/")
+        if not stripped:
+            return ""
+        return f"{stripped}/"
+
+    @contextlib.contextmanager
+    def _ca_cert_bundle(self, s3_parameters: Mapping[str, object]) -> Iterator[str | None]:
+        """Extract the S3 relation ``tls-ca-chain`` to a temporary PEM file.
+
+        The s3-integrator relation provides ``tls-ca-chain`` as a JSON list of
+        PEM strings. boto3's ``verify`` parameter accepts a path to a CA bundle
+        file, so the chain is written to a temporary file and its path yielded.
+        The file is removed once the enclosing ``with`` block exits.
+
+        Yields:
+            The path to the temporary CA bundle file, or ``None`` when the
+            relation does not provide a ``tls-ca-chain`` or it is malformed.
+        """
+        tls_ca_chain = s3_parameters.get("tls-ca-chain")
+        if not tls_ca_chain or not isinstance(tls_ca_chain, list):
+            yield None
+            return
+        fd, path = tempfile.mkstemp(suffix=".pem")
+        try:
+            with os.fdopen(fd, "w") as ca_file:
+                ca_file.write("\n".join(tls_ca_chain))
+            yield path
+        finally:
+            os.unlink(path)
 
 
 class RaftManager:

--- a/machine/.vendored/vault-package/vault/vault_s3.py
+++ b/machine/.vendored/vault-package/vault/vault_s3.py
@@ -71,6 +71,7 @@ class S3:
         application: str = "vault",
         region: str | None = AWS_DEFAULT_REGION,
         skip_verify: bool = False,
+        ca_cert_path: str | None = None,
     ):
         self.access_key = access_key
         self.secret_key = secret_key
@@ -78,11 +79,12 @@ class S3:
         self.region = region
         self._security_logger = _OWASPLogger(application=application)
 
-        if skip_verify is False:
+        if skip_verify is True:
             logger.warning(
                 "S3 client is configured to skip SSL certificate verification. "
                 "This is insecure and should only be used in development environments."
             )
+        verify = False if skip_verify else (ca_cert_path or None)
         try:
             self.session = boto3.session.Session(
                 aws_access_key_id=self.access_key,
@@ -101,7 +103,7 @@ class S3:
                 "s3",
                 endpoint_url=self.endpoint,
                 config=custom_config,
-                verify=False if skip_verify else None,
+                verify=verify,
             )
         except (ClientError, BotoCoreError, ValueError) as e:
             raise S3Error(f"Error creating session: {e}")

--- a/machine/tests/integration/conftest.py
+++ b/machine/tests/integration/conftest.py
@@ -2,13 +2,29 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import asyncio
+import logging
 import os
 from pathlib import Path
 
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from config import APP_NAME
+from config import (
+    APP_NAME,
+    JUJU_FAST_INTERVAL,
+    NUM_VAULT_UNITS,
+    S3_INTEGRATOR_APPLICATION_NAME,
+    S3_INTEGRATOR_REVISION,
+)
+from helpers import (
+    VaultInit,
+    deploy_vault,
+    get_vault_token_and_unseal_key,
+    initialize_unseal_authorize_vault,
+)
+
+logger = logging.getLogger(__name__)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -75,3 +91,44 @@ async def host_ip(ops_test: OpsTest) -> str:
     if return_code != 0:
         raise RuntimeError(f"Failed to get host IP: {stderr}")
     return stdout.strip()
+
+
+@pytest.fixture(scope="module")
+async def deploy(ops_test: OpsTest, vault_charm_path: Path, skip_deploy: bool) -> VaultInit:
+    """Deploy Vault and the S3 integrator, then initialize/unseal/authorize Vault."""
+    assert ops_test.model
+    if skip_deploy:
+        logger.info("Skipping deployment due to --no-deploy flag")
+        root_token, key = await get_vault_token_and_unseal_key(
+            ops_test.model,
+            APP_NAME,
+        )
+        return VaultInit(root_token, key)
+    await deploy_vault(
+        ops_test,
+        charm_path=vault_charm_path,
+        num_vaults=NUM_VAULT_UNITS,
+    )
+    await ops_test.model.deploy(
+        S3_INTEGRATOR_APPLICATION_NAME,
+        channel="stable",
+        revision=S3_INTEGRATOR_REVISION,
+        trust=True,
+    )
+
+    # When waiting for Vault to go to the blocked state, we may need an update
+    # status event to recognize that the API is available, so we wait in
+    # fast-forward.
+    async with ops_test.fast_forward(JUJU_FAST_INTERVAL):
+        await asyncio.gather(
+            ops_test.model.wait_for_idle(
+                apps=[S3_INTEGRATOR_APPLICATION_NAME],
+            ),
+            ops_test.model.wait_for_idle(
+                apps=[APP_NAME],
+                status="blocked",
+                wait_for_exact_units=NUM_VAULT_UNITS,
+            ),
+        )
+    root_token, unseal_key = await initialize_unseal_authorize_vault(ops_test, APP_NAME)
+    return VaultInit(root_token, unseal_key)

--- a/machine/tests/integration/helpers.py
+++ b/machine/tests/integration/helpers.py
@@ -3,9 +3,12 @@
 # See LICENSE file for licensing details.
 
 import asyncio
+import base64
+import json
 import logging
 import time
 from base64 import b64decode
+from collections import namedtuple
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
@@ -21,12 +24,19 @@ from pytest_operator.plugin import OpsTest
 from config import (
     APP_NAME,
     JUJU_FAST_INTERVAL,
+    NUM_VAULT_UNITS,
+    S3_INTEGRATOR_APPLICATION_NAME,
     SELF_SIGNED_CERTIFICATES_APPLICATION_NAME,
+    SHORT_TIMEOUT,
     VAULT_PKI_REQUIRER_APPLICATION_NAME,
 )
 from vault_helpers import Vault
 
 logger = logging.getLogger(__name__)
+
+# Returned by the shared ``deploy`` fixture in ``conftest.py`` for backup test
+# modules. Defined here so both conftest.py and test modules can import it.
+VaultInit = namedtuple("VaultInit", ["root_token", "unseal_key"])
 
 
 class ActionFailedError(Exception):
@@ -467,3 +477,111 @@ async def refresh_application(ops_test: OpsTest, app_name: str, charm_path: Path
     app = ops_test.model.applications[app_name]
     assert isinstance(app, Application)
     await app.refresh(path=charm_path)
+
+
+async def configure_s3_and_create_backup(
+    ops_test: OpsTest,
+    root_token: str,
+    s3_endpoint: str,
+    s3_access_key: str,
+    s3_secret_key: str,
+    s3_bucket: str,
+    s3_region: str,
+    kv_secret_value: str,
+    s3_path: str | None = None,
+    s3_tls_ca_chain: str | None = None,
+    skip_verify: bool = True,
+) -> str:
+    """Configure the S3 integrator, write a KV secret, and create a backup.
+
+    Returns the backup-id returned by the ``create-backup``.
+    """
+    assert ops_test.model
+    await run_action_on_leader(
+        ops_test,
+        S3_INTEGRATOR_APPLICATION_NAME,
+        "sync-s3-credentials",
+        access_key=s3_access_key,
+        secret_key=s3_secret_key,
+    )
+
+    s3_config: dict[str, str | bool] = {
+        "endpoint": s3_endpoint,
+        "bucket": s3_bucket,
+        "region": s3_region,
+    }
+    if s3_path is not None:
+        s3_config["path"] = s3_path
+    if s3_tls_ca_chain is not None:
+        s3_config["tls-ca-chain"] = base64.b64encode(s3_tls_ca_chain.encode()).decode()
+    s3_integrator = ops_test.model.applications[S3_INTEGRATOR_APPLICATION_NAME]
+    await s3_integrator.set_config(s3_config)
+    await ops_test.model.wait_for_idle(
+        apps=[S3_INTEGRATOR_APPLICATION_NAME],
+        status="active",
+        timeout=SHORT_TIMEOUT,
+    )
+
+    vault_app = ops_test.model.applications[APP_NAME]
+    if not has_relation(vault_app, "s3-parameters"):
+        await ops_test.model.integrate(
+            relation1=APP_NAME,
+            relation2=S3_INTEGRATOR_APPLICATION_NAME,
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME],
+            status="active",
+            timeout=SHORT_TIMEOUT,
+            wait_for_exact_units=NUM_VAULT_UNITS,
+        )
+
+    leader = await get_leader_unit(ops_test.model, APP_NAME)
+    vault = await get_vault_client(ops_test, leader, root_token)
+    vault.enable_kv_engine(path="kv/", description="Test KV Engine")
+    vault.write("kv/secret", {"key": kv_secret_value})
+
+    results = await run_action_on_leader(
+        ops_test, APP_NAME, "create-backup", skip_verify=skip_verify
+    )
+    return results["backup-id"]
+
+
+async def list_backups(ops_test: OpsTest, skip_verify: bool = True) -> list[str]:
+    """List backups and return the backup IDs."""
+    results = await run_action_on_leader(
+        ops_test, APP_NAME, "list-backups", skip_verify=skip_verify
+    )
+    assert results["backup-ids"] is not None
+    backup_ids = json.loads(results["backup-ids"])
+    assert len(backup_ids) > 0
+    return backup_ids
+
+
+async def restore_backup(
+    ops_test: OpsTest,
+    root_token: str,
+    kv_secret_value: str,
+    skip_verify: bool = True,
+) -> str:
+    """Restore the most recent backup and verify the KV secret is restored.
+
+    Returns the restored backup-id.
+    """
+    assert ops_test.model
+    backup_ids = await list_backups(ops_test, skip_verify=skip_verify)
+    backup_id = backup_ids[-1]
+
+    leader = await get_leader_unit(ops_test.model, APP_NAME)
+    vault = await get_vault_client(ops_test, leader, root_token)
+
+    assert vault.read("kv/secret") == {"key": kv_secret_value}
+    vault.delete("kv/secret")
+    assert vault.read("kv/secret") is None
+
+    backup_action_output = await run_action_on_leader(
+        ops_test, APP_NAME, "restore-backup", skip_verify=skip_verify, backup_id=backup_id
+    )
+
+    assert vault.read("kv/secret") == {"key": kv_secret_value}
+    assert backup_action_output["restored"] == backup_id
+    return backup_id

--- a/machine/tests/integration/test_backup.py
+++ b/machine/tests/integration/test_backup.py
@@ -1,77 +1,8 @@
-import asyncio
-import json
-import logging
-from collections import namedtuple
-from pathlib import Path
-
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from config import (
-    APP_NAME,
-    JUJU_FAST_INTERVAL,
-    MINIO_S3_ACCESS_KEY,
-    MINIO_S3_SECRET_KEY,
-    NUM_VAULT_UNITS,
-    S3_INTEGRATOR_APPLICATION_NAME,
-    S3_INTEGRATOR_REVISION,
-    SHORT_TIMEOUT,
-)
-from helpers import (
-    deploy_vault,
-    get_leader_unit,
-    get_vault_client,
-    get_vault_token_and_unseal_key,
-    has_relation,
-    initialize_unseal_authorize_vault,
-    run_action_on_leader,
-)
-
-logger = logging.getLogger(__name__)
-
-
-VaultInit = namedtuple("VaultInit", ["root_token", "unseal_key"])
-
-
-@pytest.fixture(scope="module")
-async def deploy(ops_test: OpsTest, vault_charm_path: Path, skip_deploy: bool) -> VaultInit:
-    """Build and deploy the application."""
-    assert ops_test.model
-    if skip_deploy:
-        logger.info("Skipping deployment due to --no-deploy flag")
-        root_token, key = await get_vault_token_and_unseal_key(
-            ops_test.model,
-            APP_NAME,
-        )
-        return VaultInit(root_token, key)
-    await deploy_vault(
-        ops_test,
-        charm_path=vault_charm_path,
-        num_vaults=NUM_VAULT_UNITS,
-    )
-    await ops_test.model.deploy(
-        S3_INTEGRATOR_APPLICATION_NAME,
-        channel="stable",
-        revision=S3_INTEGRATOR_REVISION,
-        trust=True,
-    )
-
-    # When waiting for Vault to go to the blocked state, we may need an update
-    # status event to recognize that the API is available, so we wait in
-    # fast-forward.
-    async with ops_test.fast_forward(JUJU_FAST_INTERVAL):
-        await asyncio.gather(
-            ops_test.model.wait_for_idle(
-                apps=[S3_INTEGRATOR_APPLICATION_NAME],
-            ),
-            ops_test.model.wait_for_idle(
-                apps=[APP_NAME],
-                status="blocked",
-                wait_for_exact_units=NUM_VAULT_UNITS,
-            ),
-        )
-    root_token, unseal_key = await initialize_unseal_authorize_vault(ops_test, APP_NAME)
-    return VaultInit(root_token, unseal_key)
+from config import MINIO_S3_ACCESS_KEY, MINIO_S3_SECRET_KEY
+from helpers import VaultInit, configure_s3_and_create_backup, list_backups, restore_backup
 
 
 @pytest.mark.abort_on_fail
@@ -80,58 +11,23 @@ async def test_given_vault_integrated_with_s3_when_create_backup_then_action_suc
     deploy: VaultInit,
     host_ip: str,
 ):
-    assert ops_test.model
-
-    await run_action_on_leader(
+    await configure_s3_and_create_backup(
         ops_test,
-        S3_INTEGRATOR_APPLICATION_NAME,
-        "sync-s3-credentials",
-        access_key=MINIO_S3_ACCESS_KEY,
-        secret_key=MINIO_S3_SECRET_KEY,
+        root_token=deploy.root_token,
+        s3_endpoint=f"https://{host_ip}:8555",
+        s3_access_key=MINIO_S3_ACCESS_KEY,
+        s3_secret_key=MINIO_S3_SECRET_KEY,
+        s3_bucket="vault-integration-test",
+        s3_region="local",
+        kv_secret_value="value",
     )
-
-    s3_config = {
-        "endpoint": f"https://{host_ip}:8555",
-        "bucket": "vault-integration-test",
-        "region": "local",
-    }
-    s3_integrator = ops_test.model.applications[S3_INTEGRATOR_APPLICATION_NAME]
-    await s3_integrator.set_config(s3_config)
-    await ops_test.model.wait_for_idle(
-        apps=[S3_INTEGRATOR_APPLICATION_NAME],
-        status="active",
-        timeout=SHORT_TIMEOUT,
-    )
-    vault_app = ops_test.model.applications[APP_NAME]
-    if not has_relation(vault_app, "s3-parameters"):
-        await ops_test.model.integrate(
-            relation1=APP_NAME,
-            relation2=S3_INTEGRATOR_APPLICATION_NAME,
-        )
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            timeout=SHORT_TIMEOUT,
-            wait_for_exact_units=NUM_VAULT_UNITS,
-        )
-    # Put a secret in the KV store so we have something to back up.
-    leader = await get_leader_unit(ops_test.model, APP_NAME)
-    vault = await get_vault_client(ops_test, leader, deploy.root_token)
-    vault.enable_kv_engine(path="kv/", description="Test KV Engine")
-    vault.write("kv/secret", {"key": "value"})
-
-    await run_action_on_leader(ops_test, APP_NAME, "create-backup", skip_verify=True)
 
 
 @pytest.mark.abort_on_fail
 async def test_given_vault_integrated_with_s3_when_list_backups_then_action_succeeds(
     ops_test: OpsTest, deploy: VaultInit
 ):
-    assert ops_test.model
-
-    results = await run_action_on_leader(ops_test, APP_NAME, "list-backups", skip_verify=True)
-    assert results["backup-ids"] is not None
-    assert len(json.loads(results["backup-ids"])) > 0
+    await list_backups(ops_test)
 
 
 @pytest.mark.abort_on_fail
@@ -139,28 +35,8 @@ async def test_given_vault_integrated_with_s3_when_restore_backup_then_action_su
     ops_test: OpsTest,
     deploy: VaultInit,
 ):
-    assert ops_test.model
-
-    list_backups_output = await run_action_on_leader(
-        ops_test, APP_NAME, "list-backups", skip_verify=True
+    await restore_backup(
+        ops_test,
+        root_token=deploy.root_token,
+        kv_secret_value="value",
     )
-
-    # Get the most recent backup ID
-    backup_id = json.loads(list_backups_output["backup-ids"])[-1]
-
-    leader = await get_leader_unit(ops_test.model, APP_NAME)
-    vault = await get_vault_client(ops_test, leader, deploy.root_token)
-    # Verify the secret is there
-    assert vault.read("kv/secret") == {"key": "value"}
-    vault.delete("kv/secret")
-
-    # Ensure the secret is deleted before restoring
-    assert vault.read("kv/secret") is None
-
-    backup_action_output = await run_action_on_leader(
-        ops_test, APP_NAME, "restore-backup", skip_verify=True, backup_id=backup_id
-    )
-
-    # Check that the secret is restored
-    assert vault.read("kv/secret") == {"key": "value"}
-    assert backup_action_output["restored"] == backup_id

--- a/machine/tests/integration/test_backup_tls.py
+++ b/machine/tests/integration/test_backup_tls.py
@@ -1,0 +1,241 @@
+import datetime
+import ipaddress
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+from collections.abc import AsyncIterator
+
+import boto3
+import pytest
+from botocore.config import Config as BotoConfig
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from pytest_operator.plugin import OpsTest
+
+from config import APP_NAME, MINIO_S3_ACCESS_KEY, MINIO_S3_SECRET_KEY
+from helpers import (
+    VaultInit,
+    configure_s3_and_create_backup,
+    get_leader_unit,
+    get_vault_client,
+    list_backups,
+    restore_backup,
+    run_action_on_leader,
+)
+
+# Path prefix configured on the s3-integrator.
+S3_PATH = "vault"
+# The bucket name used by the test MinIO instance.
+S3_BUCKET = "vault-integration-test"
+# The port for the test MinIO server (avoid conflicts with LXD bucket server's 8555).
+MINIO_PORT = 16666
+
+
+@pytest.fixture(scope="module")
+async def minio_endpoint_and_ca_cert(
+    ops_test: OpsTest, host_ip: str
+) -> AsyncIterator[tuple[str, str]]:
+    """Start a MinIO server with a self-signed TLS cert and return its endpoint + CA cert.
+
+    The cert's SAN includes the lxdbr0 gateway IP so that hostname verification
+    passes when Vault units connect to the endpoint from inside LXD containers.
+    Yields a ``(endpoint, ca_cert_pem)`` tuple. The MinIO process and temp
+    files are cleaned up when the fixture goes out of scope.
+    """
+    cert_dir = tempfile.mkdtemp(prefix="minio-certs-")
+    data_dir = tempfile.mkdtemp(prefix="minio-data-")
+    try:
+        # Generate a self-signed cert with the lxdbr0 IP as a SAN.
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        subject = x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, host_ip)])
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(subject)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime.utcnow())
+            .not_valid_after(
+                datetime.datetime.utcnow().replace(year=datetime.datetime.utcnow().year + 1)
+            )
+            .add_extension(
+                x509.SubjectAlternativeName([x509.IPAddress(ipaddress.ip_address(host_ip))]),
+                critical=False,
+            )
+            .sign(key, hashes.SHA256())
+        )
+        key_path = os.path.join(cert_dir, "private.key")
+        cert_path = os.path.join(cert_dir, "public.crt")
+        with open(key_path, "wb") as f:
+            f.write(
+                key.private_bytes(
+                    serialization.Encoding.PEM,
+                    serialization.PrivateFormat.TraditionalOpenSSL,
+                    serialization.NoEncryption(),
+                )
+            )
+        with open(cert_path, "wb") as f:
+            f.write(cert.public_bytes(serialization.Encoding.PEM))
+        ca_cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+
+        # Find the minio binary.
+        # In github ci it's installed to /var/snap/lxd/common/minio/minio.
+        # When testing locally, it may be on PATH.
+        minio_bin = shutil.which("minio") or "/var/snap/lxd/common/minio/minio"
+
+        # Start MinIO with TLS.
+        proc = subprocess.Popen(
+            [
+                minio_bin,
+                "server",
+                f"--address={host_ip}:{MINIO_PORT}",
+                f"--certs-dir={cert_dir}",
+                data_dir,
+            ],
+            env={
+                **os.environ,
+                "MINIO_ROOT_USER": MINIO_S3_ACCESS_KEY,
+                "MINIO_ROOT_PASSWORD": MINIO_S3_SECRET_KEY,
+            },
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            # Wait for MinIO to start listening.
+            for _ in range(30):
+                try:
+                    with socket.create_connection((host_ip, MINIO_PORT), timeout=2):
+                        break
+                except (ConnectionRefusedError, OSError):
+                    time.sleep(1)
+            else:
+                raise RuntimeError("MinIO did not start within 30s")
+
+            session = boto3.session.Session(
+                aws_access_key_id=MINIO_S3_ACCESS_KEY,
+                aws_secret_access_key=MINIO_S3_SECRET_KEY,
+                region_name="local",
+            )
+            s3 = session.resource(
+                "s3",
+                endpoint_url=f"https://{host_ip}:{MINIO_PORT}",
+                verify=cert_path,
+                config=BotoConfig(
+                    request_checksum_calculation="when_required",
+                    response_checksum_validation="when_required",
+                ),
+            )
+            s3.create_bucket(Bucket=S3_BUCKET)
+
+            endpoint = f"https://{host_ip}:{MINIO_PORT}"
+            yield endpoint, ca_cert_pem
+        finally:
+            proc.terminate()
+            proc.wait(timeout=10)
+    finally:
+        shutil.rmtree(cert_dir, ignore_errors=True)
+        shutil.rmtree(data_dir, ignore_errors=True)
+
+
+@pytest.mark.abort_on_fail
+async def test_given_self_signed_tls_endpoint_and_ca_chain_when_create_backup_then_succeeds_with_prefixed_key(
+    ops_test: OpsTest,
+    deploy: VaultInit,
+    minio_endpoint_and_ca_cert: tuple[str, str],
+):
+    endpoint, ca_cert = minio_endpoint_and_ca_cert
+    backup_id = await configure_s3_and_create_backup(
+        ops_test,
+        root_token=deploy.root_token,
+        s3_endpoint=endpoint,
+        s3_access_key=MINIO_S3_ACCESS_KEY,
+        s3_secret_key=MINIO_S3_SECRET_KEY,
+        s3_bucket=S3_BUCKET,
+        s3_region="local",
+        kv_secret_value="tls-value",
+        s3_path=S3_PATH,
+        s3_tls_ca_chain=ca_cert,
+        skip_verify=False,
+    )
+    assert backup_id.startswith(f"{S3_PATH}/vault-backup-"), backup_id
+
+
+@pytest.mark.abort_on_fail
+async def test_given_path_set_when_list_backups_then_keys_are_prefixed(
+    ops_test: OpsTest,
+    deploy: VaultInit,
+):
+    backup_ids = await list_backups(ops_test, skip_verify=False)
+    assert backup_ids, "Expected at least one backup"
+    assert all(bid.startswith(f"{S3_PATH}/") for bid in backup_ids), backup_ids
+
+
+@pytest.mark.abort_on_fail
+async def test_given_prefixed_backup_when_restore_backup_then_succeeds(
+    ops_test: OpsTest,
+    deploy: VaultInit,
+):
+    restored_id = await restore_backup(
+        ops_test,
+        root_token=deploy.root_token,
+        kv_secret_value="tls-value",
+        skip_verify=False,
+    )
+    assert restored_id.startswith(f"{S3_PATH}/"), restored_id
+
+
+@pytest.mark.abort_on_fail
+async def test_given_legacy_root_level_backup_when_restore_backup_then_falls_back(
+    ops_test: OpsTest,
+    deploy: VaultInit,
+    minio_endpoint_and_ca_cert: tuple[str, str],
+):
+    endpoint, ca_cert = minio_endpoint_and_ca_cert
+
+    # Take a real raft snapshot via the leader's Vault API.
+    assert ops_test.model
+    leader = await get_leader_unit(ops_test.model, APP_NAME)
+    vault = await get_vault_client(ops_test, leader, deploy.root_token)
+    snapshot_bytes = vault.client.sys.take_raft_snapshot().content
+
+    # Upload the snapshot as a legacy root-level object (no path prefix).
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False) as ca_file:
+        ca_file.write(ca_cert)
+        ca_path = ca_file.name
+    try:
+        session = boto3.session.Session(
+            aws_access_key_id=MINIO_S3_ACCESS_KEY,
+            aws_secret_access_key=MINIO_S3_SECRET_KEY,
+            region_name="local",
+        )
+        s3 = session.resource(
+            "s3",
+            endpoint_url=endpoint,
+            verify=ca_path,
+            config=BotoConfig(
+                request_checksum_calculation="when_required",
+                response_checksum_validation="when_required",
+            ),
+        )
+        legacy_key = "vault-backup-legacy-root-level"
+        s3.Bucket(S3_BUCKET).put_object(
+            Key=legacy_key,
+            Body=snapshot_bytes,
+        )
+    finally:
+        os.unlink(ca_path)
+
+    # The legacy key has no path prefix; restore-backup must fall back to it.
+    # Use run_action_on_leader directly so we target the legacy key explicitly.
+    results = await run_action_on_leader(
+        ops_test,
+        APP_NAME,
+        "restore-backup",
+        backup_id=legacy_key,
+        skip_verify=False,
+    )
+    assert results["restored"] == legacy_key, results

--- a/vault-package/tests/unit/test_vault_client.py
+++ b/vault-package/tests/unit/test_vault_client.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
-from hvac.exceptions import Forbidden, InternalServerError
+from hvac.exceptions import Forbidden, InternalServerError, InvalidRequest
 
 from vault.vault_client import (
     AppRole,
@@ -16,6 +16,7 @@ from vault.vault_client import (
     SecretsBackend,
     Token,
     VaultClient,
+    VaultClientError,
 )
 
 TEST_PATH = "./tests/unit"

--- a/vault-package/tests/unit/test_vault_s3.py
+++ b/vault-package/tests/unit/test_vault_s3.py
@@ -391,6 +391,71 @@ class TestS3(unittest.TestCase):
             verify=None,
         )
 
+    @patch("boto3.session.Session")
+    def test_given_ca_cert_path_when_create_s3_session_then_verify_is_ca_cert_path(
+        self,
+        patch_session: MagicMock,
+    ):
+        S3(
+            access_key=self.VALID_S3_PARAMETERS["access-key"],
+            secret_key=self.VALID_S3_PARAMETERS["secret-key"],
+            region=self.VALID_S3_PARAMETERS["region"],
+            endpoint=self.VALID_S3_PARAMETERS["endpoint"],
+            application="vault",
+            skip_verify=False,
+            ca_cert_path="/tmp/ca-chain.pem",
+        )
+        patch_session.return_value.resource.assert_called_with(
+            "s3",
+            endpoint_url=self.VALID_S3_PARAMETERS["endpoint"],
+            config=ANY,
+            verify="/tmp/ca-chain.pem",
+        )
+
+    @patch("boto3.session.Session")
+    def test_given_ca_cert_path_and_skip_verify_when_create_s3_session_then_verify_is_false(
+        self,
+        patch_session: MagicMock,
+    ):
+        # skip_verify takes precedence over ca_cert_path so that operators can
+        # explicitly opt out of TLS verification even when a CA chain is set.
+        S3(
+            access_key=self.VALID_S3_PARAMETERS["access-key"],
+            secret_key=self.VALID_S3_PARAMETERS["secret-key"],
+            region=self.VALID_S3_PARAMETERS["region"],
+            endpoint=self.VALID_S3_PARAMETERS["endpoint"],
+            application="vault",
+            skip_verify=True,
+            ca_cert_path="/tmp/ca-chain.pem",
+        )
+        patch_session.return_value.resource.assert_called_with(
+            "s3",
+            endpoint_url=self.VALID_S3_PARAMETERS["endpoint"],
+            config=ANY,
+            verify=False,
+        )
+
+    @patch("boto3.session.Session")
+    def test_given_no_ca_cert_path_and_skip_verify_false_when_create_s3_session_then_verify_is_none(
+        self,
+        patch_session: MagicMock,
+    ):
+        S3(
+            access_key=self.VALID_S3_PARAMETERS["access-key"],
+            secret_key=self.VALID_S3_PARAMETERS["secret-key"],
+            region=self.VALID_S3_PARAMETERS["region"],
+            endpoint=self.VALID_S3_PARAMETERS["endpoint"],
+            application="vault",
+            skip_verify=False,
+            ca_cert_path=None,
+        )
+        patch_session.return_value.resource.assert_called_with(
+            "s3",
+            endpoint_url=self.VALID_S3_PARAMETERS["endpoint"],
+            config=ANY,
+            verify=None,
+        )
+
     @patch.dict(
         "os.environ",
         {

--- a/vault-package/vault/vault_managers.py
+++ b/vault-package/vault/vault_managers.py
@@ -28,14 +28,16 @@ Feature managers should not:
 - Depend on each other unless the features explicitly require the dependency.
 """
 
+import contextlib
 import json
 import logging
 import os
+import tempfile
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from enum import Enum, auto
 from functools import cached_property
-from typing import FrozenSet, List, MutableMapping, Optional, Sequence, TextIO
+from typing import FrozenSet, Iterator, List, Mapping, MutableMapping, TextIO
 
 from charms.certificate_transfer_interface.v1.certificate_transfer import (
     CertificateTransferProvides,
@@ -1537,40 +1539,43 @@ class BackupManager:
         self._validate_s3_prerequisites()
 
         s3_parameters = self._get_s3_parameters()
+        path_prefix = self._normalize_path(s3_parameters)
+        with self._ca_cert_bundle(s3_parameters) as ca_cert_path:
+            try:
+                s3 = S3(
+                    access_key=s3_parameters["access-key"],
+                    secret_key=s3_parameters["secret-key"],
+                    endpoint=s3_parameters["endpoint"],
+                    region=s3_parameters.get("region"),
+                    skip_verify=skip_verify,
+                    application=self._charm.app.name,
+                    ca_cert_path=ca_cert_path,
+                )
+            except S3Error as e:
+                logger.error("Failed to create S3 session. %s", e)
+                raise ManagerError("Failed to create S3 session")
 
-        try:
-            s3 = S3(
-                access_key=s3_parameters["access-key"],
-                secret_key=s3_parameters["secret-key"],
-                endpoint=s3_parameters["endpoint"],
-                region=s3_parameters.get("region"),
-                skip_verify=skip_verify,
-                application=self._charm.app.name,
+            if not (s3.create_bucket(bucket_name=s3_parameters["bucket"])):
+                raise ManagerError("Failed to create S3 bucket")
+            backup_key = f"{path_prefix}{Naming.backup_s3_key_name(self._charm.model.name)}"
+
+            response = vault_client.create_snapshot()
+            content_uploaded = s3.upload_content(
+                content=response.raw,  # type: ignore[reportArgumentType]
+                bucket_name=s3_parameters["bucket"],
+                key=backup_key,
             )
-        except S3Error as e:
-            logger.error("Failed to create S3 session. %s", e)
-            raise ManagerError("Failed to create S3 session")
-
-        if not (s3.create_bucket(bucket_name=s3_parameters["bucket"])):
-            raise ManagerError("Failed to create S3 bucket")
-        backup_key = Naming.backup_s3_key_name(self._charm.model.name)
-
-        response = vault_client.create_snapshot()
-        content_uploaded = s3.upload_content(
-            content=response.raw,  # type: ignore[reportArgumentType]
-            bucket_name=s3_parameters["bucket"],
-            key=backup_key,
-        )
-        if not content_uploaded:
-            raise ManagerError("Failed to upload backup to S3 bucket")
-        logger.info("Backup uploaded to S3 bucket %s", s3_parameters["bucket"])
-        return backup_key
+            if not content_uploaded:
+                raise ManagerError("Failed to upload backup to S3 bucket")
+            logger.info("Backup uploaded to S3 bucket %s", s3_parameters["bucket"])
+            return backup_key
 
     def list_backups(self, skip_verify: bool = False) -> list[str]:
         """List all the backups available in the S3 bucket.
 
         Backups are identified by the key prefix from
-        ``Naming.backup_s3_key_prefix``.
+        ``Naming.backup_s3_key_prefix``, prepended with the S3 relation
+        ``path`` when one is configured.
 
         Args:
             skip_verify: Whether to skip verification of the S3 connection.
@@ -1581,26 +1586,29 @@ class BackupManager:
         self._validate_s3_prerequisites()
 
         s3_parameters = self._get_s3_parameters()
+        path_prefix = self._normalize_path(s3_parameters)
+        with self._ca_cert_bundle(s3_parameters) as ca_cert_path:
+            try:
+                s3 = S3(
+                    access_key=s3_parameters["access-key"],
+                    secret_key=s3_parameters["secret-key"],
+                    endpoint=s3_parameters["endpoint"],
+                    region=s3_parameters.get("region"),
+                    skip_verify=skip_verify,
+                    application=self._charm.app.name,
+                    ca_cert_path=ca_cert_path,
+                )
+            except S3Error:
+                raise ManagerError("Failed to create S3 session")
 
-        try:
-            s3 = S3(
-                access_key=s3_parameters["access-key"],
-                secret_key=s3_parameters["secret-key"],
-                endpoint=s3_parameters["endpoint"],
-                region=s3_parameters.get("region"),
-                skip_verify=skip_verify,
-                application=self._charm.app.name,
-            )
-        except S3Error:
-            raise ManagerError("Failed to create S3 session")
-
-        try:
-            backup_ids = s3.get_object_key_list(
-                bucket_name=s3_parameters["bucket"], prefix=Naming.backup_s3_key_prefix
-            )
-        except S3Error as e:
-            raise ManagerError(f"Failed to list backups in S3 bucket: {e}")
-        return backup_ids
+            try:
+                backup_ids = s3.get_object_key_list(
+                    bucket_name=s3_parameters["bucket"],
+                    prefix=f"{path_prefix}{Naming.backup_s3_key_prefix}",
+                )
+            except S3Error as e:
+                raise ManagerError(f"Failed to list backups in S3 bucket: {e}")
+            return backup_ids
 
     def restore_backup(
         self, vault_client: VaultClient, backup_key: str, skip_verify: bool = False
@@ -1615,35 +1623,50 @@ class BackupManager:
         self._validate_s3_prerequisites()
 
         s3_parameters = self._get_s3_parameters()
+        path_prefix = self._normalize_path(s3_parameters)
+        with self._ca_cert_bundle(s3_parameters) as ca_cert_path:
+            try:
+                s3 = S3(
+                    access_key=s3_parameters["access-key"],
+                    secret_key=s3_parameters["secret-key"],
+                    endpoint=s3_parameters["endpoint"],
+                    region=s3_parameters.get("region"),
+                    skip_verify=skip_verify,
+                    application=self._charm.app.name,
+                    ca_cert_path=ca_cert_path,
+                )
+            except S3Error:
+                raise ManagerError("Failed to create S3 session")
 
-        try:
-            s3 = S3(
-                access_key=s3_parameters["access-key"],
-                secret_key=s3_parameters["secret-key"],
-                endpoint=s3_parameters["endpoint"],
-                region=s3_parameters.get("region"),
-                skip_verify=skip_verify,
-                application=self._charm.app.name,
-            )
-        except S3Error:
-            raise ManagerError("Failed to create S3 session")
+            # If the supplied key is already prefixed, fetch it directly.
+            # Otherwise try the path-prefixed key first and fall back to the raw key.
+            if path_prefix and backup_key.startswith(path_prefix):
+                candidates = [backup_key]
+            else:
+                prefixed_key = f"{path_prefix}{backup_key}"
+                candidates = (
+                    [prefixed_key] if prefixed_key == backup_key else [prefixed_key, backup_key]
+                )
+            try:
+                snapshot = None
+                for candidate in candidates:
+                    snapshot = s3.get_content(
+                        bucket_name=s3_parameters["bucket"],
+                        object_key=candidate,
+                    )
+                    if snapshot:
+                        break
+            except S3Error as e:
+                raise ManagerError(f"Failed to retrieve snapshot from S3: {e}")
+            if not snapshot:
+                raise ManagerError(
+                    f"Snapshot not found in S3 bucket. ({s3_parameters['bucket']}/{backup_key})"
+                )
 
-        try:
-            snapshot = s3.get_content(
-                bucket_name=s3_parameters["bucket"],
-                object_key=backup_key,
-            )
-        except S3Error as e:
-            raise ManagerError(f"Failed to retrieve snapshot from S3: {e}")
-        if not snapshot:
-            raise ManagerError(
-                f"Snapshot not found in S3 bucket. ({s3_parameters['bucket']}/{backup_key})"
-            )
-
-        try:
-            vault_client.restore_snapshot(snapshot=snapshot)
-        except VaultClientError as e:
-            raise ManagerError(f"Failed to restore snapshot: {e}")
+            try:
+                vault_client.restore_snapshot(snapshot=snapshot)
+            except VaultClientError as e:
+                raise ManagerError(f"Failed to restore snapshot: {e}")
 
     def _validate_s3_prerequisites(self) -> str | None:
         """Validate the S3 pre-requisites are met.
@@ -1680,6 +1703,53 @@ class BackupManager:
             if isinstance(value, str):
                 s3_parameters[key] = value.strip()
         return s3_parameters
+
+    def _normalize_path(self, s3_parameters: Mapping[str, object]) -> str:
+        """Return the S3 relation ``path`` as a normalized key prefix.
+
+        Strips leading and trailing slashes from the ``path`` field and
+        appends a trailing slash so it can be prepended to object keys.
+        Returns an empty string when no path is configured, so it is a no-op
+        when ``path`` is absent.
+
+        Args:
+            s3_parameters: S3 relation parameters.
+
+        Returns:
+            A prefix such as ``"vault/"`` or an empty string.
+        """
+        path = s3_parameters.get("path")
+        if not path or not isinstance(path, str):
+            return ""
+        stripped = path.strip("/")
+        if not stripped:
+            return ""
+        return f"{stripped}/"
+
+    @contextlib.contextmanager
+    def _ca_cert_bundle(self, s3_parameters: Mapping[str, object]) -> Iterator[str | None]:
+        """Extract the S3 relation ``tls-ca-chain`` to a temporary PEM file.
+
+        The s3-integrator relation provides ``tls-ca-chain`` as a JSON list of
+        PEM strings. boto3's ``verify`` parameter accepts a path to a CA bundle
+        file, so the chain is written to a temporary file and its path yielded.
+        The file is removed once the enclosing ``with`` block exits.
+
+        Yields:
+            The path to the temporary CA bundle file, or ``None`` when the
+            relation does not provide a ``tls-ca-chain`` or it is malformed.
+        """
+        tls_ca_chain = s3_parameters.get("tls-ca-chain")
+        if not tls_ca_chain or not isinstance(tls_ca_chain, list):
+            yield None
+            return
+        fd, path = tempfile.mkstemp(suffix=".pem")
+        try:
+            with os.fdopen(fd, "w") as ca_file:
+                ca_file.write("\n".join(tls_ca_chain))
+            yield path
+        finally:
+            os.unlink(path)
 
 
 class RaftManager:

--- a/vault-package/vault/vault_s3.py
+++ b/vault-package/vault/vault_s3.py
@@ -71,6 +71,7 @@ class S3:
         application: str = "vault",
         region: str | None = AWS_DEFAULT_REGION,
         skip_verify: bool = False,
+        ca_cert_path: str | None = None,
     ):
         self.access_key = access_key
         self.secret_key = secret_key
@@ -78,11 +79,12 @@ class S3:
         self.region = region
         self._security_logger = _OWASPLogger(application=application)
 
-        if skip_verify is False:
+        if skip_verify is True:
             logger.warning(
                 "S3 client is configured to skip SSL certificate verification. "
                 "This is insecure and should only be used in development environments."
             )
+        verify = False if skip_verify else (ca_cert_path or None)
         try:
             self.session = boto3.session.Session(
                 aws_access_key_id=self.access_key,
@@ -101,7 +103,7 @@ class S3:
                 "s3",
                 endpoint_url=self.endpoint,
                 config=custom_config,
-                verify=False if skip_verify else None,
+                verify=verify,
             )
         except (ClientError, BotoCoreError, ValueError) as e:
             raise S3Error(f"Error creating session: {e}")


### PR DESCRIPTION
# Description

This PR backports the fix landed in main in PR https://github.com/canonical/vault-k8s-operator/pull/1041

The backport had to re-tool the integration tests to use the pytest_operator style, not jubilant.

Everything else - the core business logic of the fix - backported cleanly.

If fixes 2 bugs related to creating vault backups:

    fixes https://github.com/canonical/vault-k8s-operator/issues/958
    fixes https://github.com/canonical/vault-k8s-operator/issues/1035

There are also drive by fixes for:

   - inverted check for logging insecure connection warning
   - deduplicate deploy() helper in integration tests
   - existing unit test failure due to missing imports

With the ca cert fix, it was a matter of extracting the tls-ca-chain attribute from the s3 relation and passing that value (as a temporary file) as the ca_cert_path arg to the S3 class.

With the backup path fix, it was a matter of using the path attribute from the s3 relation. If not specified, it falls back to the current behaviour of using the bucket root.

New integration tests are added to test_backup_tls.py. This is for machine. The vendored code is identical for k8s.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of any required library.
